### PR TITLE
Tianpok/refactor aaa unit tests

### DIFF
--- a/src/test/java/sc2002/turnbased/domain/CombatStatsTest.java
+++ b/src/test/java/sc2002/turnbased/domain/CombatStatsTest.java
@@ -10,25 +10,53 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 class CombatStatsTest {
     @Test
-    void combatStatsUsesValueObjectsDirectly() {
-        CombatStats combatStats = new CombatStats(
-            new HitPoints(120, 120),
-            Map.of(
-                StatType.ATTACK, new Stat(45),
-                StatType.DEFENSE, new Stat(15),
-                StatType.SPEED, new Stat(25)
-            )
-        );
+    void valueOf_whenStatExists_returnsConfiguredValue() {
+        CombatStats combatStats = createCombatStats();
 
-        assertEquals(new HitPoints(120, 120), combatStats.hitPoints());
-        assertEquals(new Stat(45), combatStats.stats().get(StatType.ATTACK));
-        assertEquals(new Stat(15), combatStats.stats().get(StatType.DEFENSE));
-        assertEquals(new Stat(25), combatStats.stats().get(StatType.SPEED));
+        int attack = combatStats.valueOf(StatType.ATTACK);
+
+        assertEquals(45, attack);
     }
 
     @Test
-    void withersReplaceOnlyRequestedField() {
+    void valueOf_whenStatIsMissing_returnsZero() {
         CombatStats combatStats = new CombatStats(
+            new HitPoints(120, 120),
+            Map.of(
+                StatType.ATTACK, new Stat(45)
+            )
+        );
+
+        int speed = combatStats.valueOf(StatType.SPEED);
+
+        assertEquals(0, speed);
+    }
+
+    @Test
+    void withHitPoints_whenReplacingHitPoints_keepsExistingStats() {
+        CombatStats combatStats = createCombatStats();
+        HitPoints updatedHitPoints = new HitPoints(70, 120);
+
+        CombatStats updated = combatStats.withHitPoints(updatedHitPoints);
+
+        assertEquals(updatedHitPoints, updated.hitPoints());
+        assertEquals(combatStats.stats(), updated.stats());
+    }
+
+    @Test
+    void withStat_whenReplacingAttack_keepsOtherFieldsUnchanged() {
+        CombatStats combatStats = createCombatStats();
+
+        CombatStats updated = combatStats.withStat(StatType.ATTACK, new Stat(55));
+
+        assertEquals(combatStats.hitPoints(), updated.hitPoints());
+        assertEquals(new Stat(55), updated.stats().get(StatType.ATTACK));
+        assertEquals(combatStats.stats().get(StatType.DEFENSE), updated.stats().get(StatType.DEFENSE));
+        assertEquals(combatStats.stats().get(StatType.SPEED), updated.stats().get(StatType.SPEED));
+    }
+
+    private static CombatStats createCombatStats() {
+        return new CombatStats(
             new HitPoints(120, 120),
             Map.of(
                 StatType.ATTACK, new Stat(45),
@@ -36,12 +64,5 @@ class CombatStatsTest {
                 StatType.SPEED, new Stat(25)
             )
         );
-        CombatStats updated = combatStats.withHitPoints(new HitPoints(70, 120))
-            .withStat(StatType.ATTACK, new Stat(55));
-
-        assertEquals(new HitPoints(70, 120), updated.hitPoints());
-        assertEquals(new Stat(55), updated.stats().get(StatType.ATTACK));
-        assertEquals(new Stat(15), updated.stats().get(StatType.DEFENSE));
-        assertEquals(new Stat(25), updated.stats().get(StatType.SPEED));
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/CombatantTest.java
+++ b/src/test/java/sc2002/turnbased/domain/CombatantTest.java
@@ -1,6 +1,7 @@
 package sc2002.turnbased.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static sc2002.turnbased.support.TestCombatantBuilder.aCombatant;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.Test;
 class CombatantTest {
     @Test
     void receiveDamage_whenDamageIsApplied_updatesHitPointsByDamageAmount() {
-        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        Combatant combatant = aCombatant().build();
         HitPoints initialHitPoints = combatant.getHitPoints();
 
         combatant.receiveDamage(35);
@@ -22,7 +23,9 @@ class CombatantTest {
 
     @Test
     void heal_whenHealingWouldExceedMaxHp_capsCurrentHpAtMax() {
-        Combatant combatant = testCombatant(80, 100, 40, 20, 30);
+        Combatant combatant = aCombatant()
+            .withCurrentHp(80)
+            .build();
 
         combatant.heal(50);
 
@@ -31,7 +34,7 @@ class CombatantTest {
 
     @Test
     void adjustStat_whenAttackBuffIsApplied_increasesResolvedAttackWithoutChangingBaseAttack() {
-        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        Combatant combatant = aCombatant().build();
         int baseAttack = combatant.getBaseAttack();
 
         combatant.adjustStat(StatType.ATTACK, 10);
@@ -42,7 +45,7 @@ class CombatantTest {
 
     @Test
     void getSpeed_whenPersistentModifierIsApplied_returnsModifiedSpeed() {
-        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        Combatant combatant = aCombatant().build();
         int baseSpeed = combatant.getSpeed();
 
         combatant.adjustStat(StatType.SPEED, 5);
@@ -52,7 +55,7 @@ class CombatantTest {
 
     @Test
     void getDefense_whenDefendStatusEffectIsActive_includesTemporaryDefenseBonus() {
-        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        Combatant combatant = aCombatant().build();
         int baseDefense = combatant.getDefense();
 
         combatant.addStatusEffect(new DefendStatusEffect(1));
@@ -62,30 +65,12 @@ class CombatantTest {
 
     @Test
     void getDefense_whenDefendStatusEffectExpires_returnsToBaseDefense() {
-        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        Combatant combatant = aCombatant().build();
         int baseDefense = combatant.getDefense();
 
         combatant.addStatusEffect(new DefendStatusEffect(1));
         combatant.statusEffects().onRoundCompleted();
 
         assertEquals(baseDefense, combatant.getDefense());
-    }
-
-    private static Combatant testCombatant(int currentHp, int maxHp, int attack, int defense, int speed) {
-        return new TestCombatant(
-            "Test Combatant",
-            CombatStats.of(
-                new HitPoints(currentHp, maxHp),
-                new Stat(attack),
-                new Stat(defense),
-                new Stat(speed)
-            )
-        );
-    }
-
-    private static final class TestCombatant extends Combatant {
-        private TestCombatant(String name, CombatStats baseStats) {
-            super(name, baseStats);
-        }
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/CombatantTest.java
+++ b/src/test/java/sc2002/turnbased/domain/CombatantTest.java
@@ -8,45 +8,84 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 class CombatantTest {
     @Test
-    void combatantHpMutationsFlowThroughHitPointsValueObject() {
-        Warrior warrior = new Warrior();
+    void receiveDamage_whenDamageIsApplied_updatesHitPointsByDamageAmount() {
+        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        HitPoints initialHitPoints = combatant.getHitPoints();
 
-        warrior.receiveDamage(90);
-        assertEquals(new HitPoints(170, 260), warrior.getHitPoints());
+        combatant.receiveDamage(35);
 
-        warrior.heal(500);
-        assertEquals(new HitPoints(260, 260), warrior.getHitPoints());
+        assertEquals(
+            new HitPoints(initialHitPoints.current() - 35, initialHitPoints.max()),
+            combatant.getHitPoints()
+        );
     }
 
     @Test
-    void attackBuffChangesCurrentAttackWithoutMutatingBaseAttack() {
-        Wizard wizard = new Wizard();
+    void heal_whenHealingWouldExceedMaxHp_capsCurrentHpAtMax() {
+        Combatant combatant = testCombatant(80, 100, 40, 20, 30);
 
-        wizard.adjustStat(StatType.ATTACK, 10);
+        combatant.heal(50);
 
-        assertEquals(60, wizard.getAttack());
-        assertEquals(50, wizard.getBaseAttack());
+        assertEquals(new HitPoints(100, 100), combatant.getHitPoints());
     }
 
     @Test
-    void genericStatResolutionSupportsFutureStatModifiers() {
-        Warrior warrior = new Warrior();
+    void adjustStat_whenAttackBuffIsApplied_increasesResolvedAttackWithoutChangingBaseAttack() {
+        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        int baseAttack = combatant.getBaseAttack();
 
-        warrior.adjustStat(StatType.SPEED, 5);
+        combatant.adjustStat(StatType.ATTACK, 10);
 
-        assertEquals(35, warrior.getSpeed());
+        assertEquals(baseAttack + 10, combatant.getAttack());
+        assertEquals(baseAttack, combatant.getBaseAttack());
     }
 
     @Test
-    void defendEffectTemporarilyRaisesDefense() {
-        Warrior warrior = new Warrior();
+    void getSpeed_whenPersistentModifierIsApplied_returnsModifiedSpeed() {
+        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        int baseSpeed = combatant.getSpeed();
 
-        assertEquals(20, warrior.getDefense());
-        warrior.addStatusEffect(new DefendStatusEffect(1));
-        assertEquals(30, warrior.getDefense());
+        combatant.adjustStat(StatType.SPEED, 5);
 
-        warrior.statusEffects().onRoundCompleted();
+        assertEquals(baseSpeed + 5, combatant.getSpeed());
+    }
 
-        assertEquals(20, warrior.getDefense());
+    @Test
+    void getDefense_whenDefendStatusEffectIsActive_includesTemporaryDefenseBonus() {
+        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        int baseDefense = combatant.getDefense();
+
+        combatant.addStatusEffect(new DefendStatusEffect(1));
+
+        assertEquals(baseDefense + 10, combatant.getDefense());
+    }
+
+    @Test
+    void getDefense_whenDefendStatusEffectExpires_returnsToBaseDefense() {
+        Combatant combatant = testCombatant(100, 100, 40, 20, 30);
+        int baseDefense = combatant.getDefense();
+
+        combatant.addStatusEffect(new DefendStatusEffect(1));
+        combatant.statusEffects().onRoundCompleted();
+
+        assertEquals(baseDefense, combatant.getDefense());
+    }
+
+    private static Combatant testCombatant(int currentHp, int maxHp, int attack, int defense, int speed) {
+        return new TestCombatant(
+            "Test Combatant",
+            CombatStats.of(
+                new HitPoints(currentHp, maxHp),
+                new Stat(attack),
+                new Stat(defense),
+                new Stat(speed)
+            )
+        );
+    }
+
+    private static final class TestCombatant extends Combatant {
+        private TestCombatant(String name, CombatStats baseStats) {
+            super(name, baseStats);
+        }
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/HitPointsTest.java
+++ b/src/test/java/sc2002/turnbased/domain/HitPointsTest.java
@@ -10,33 +10,53 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 class HitPointsTest {
     @Test
-    void takeDamageClampsAtZero() {
+    void takeDamage_whenDamageExceedsCurrentHp_capsCurrentHpAtZero() {
         HitPoints hitPoints = new HitPoints(70, 100);
 
-        assertEquals(new HitPoints(0, 100), hitPoints.takeDamage(90));
+        HitPoints updatedHitPoints = hitPoints.takeDamage(90);
+
+        assertEquals(new HitPoints(0, 100), updatedHitPoints);
     }
 
     @Test
-    void healCapsAtMaximum() {
+    void heal_whenHealingExceedsMaxHp_capsCurrentHpAtMax() {
         HitPoints hitPoints = new HitPoints(40, 100);
 
-        assertEquals(new HitPoints(100, 100), hitPoints.heal(80));
+        HitPoints updatedHitPoints = hitPoints.heal(80);
+
+        assertEquals(new HitPoints(100, 100), updatedHitPoints);
     }
 
     @Test
-    void constructorRejectsInvalidValues() {
+    void constructor_whenCurrentHpIsNegative_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new HitPoints(-1, 100));
+    }
+
+    @Test
+    void constructor_whenCurrentHpExceedsMaxHp_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new HitPoints(101, 100));
+    }
+
+    @Test
+    void constructor_whenMaxHpIsNotPositive_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new HitPoints(0, 0));
     }
 
     @Test
-    void isDeadReturnsTrueAtZeroHp() {
-        assertTrue(new HitPoints(0, 100).isDead());
+    void isDead_whenCurrentHpIsZero_returnsTrue() {
+        HitPoints hitPoints = new HitPoints(0, 100);
+
+        boolean isDead = hitPoints.isDead();
+
+        assertTrue(isDead);
     }
 
     @Test
-    void healthPercentageReflectsCurrentHealth() {
-        assertEquals(25.0, new HitPoints(25, 100).getHealthPercentage());
+    void getHealthPercentage_whenCurrentHpIsQuarterOfMax_returnsTwentyFivePercent() {
+        HitPoints hitPoints = new HitPoints(25, 100);
+
+        double healthPercentage = hitPoints.getHealthPercentage();
+
+        assertEquals(25.0, healthPercentage);
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/SpecialSkillTest.java
+++ b/src/test/java/sc2002/turnbased/domain/SpecialSkillTest.java
@@ -12,21 +12,47 @@ import sc2002.turnbased.actions.ShieldBashAction;
 @Tag("unit")
 class SpecialSkillTest {
     @Test
-    void specialSkillTracksCooldownOutsideCombatant() {
-        SpecialSkill specialSkill = new SpecialSkill(new ShieldBashAction(), 3);
+    void isAvailable_whenCooldownHasNotBeenTriggered_returnsTrue() {
+        SpecialSkill specialSkill = specialSkillWithCooldown(3);
 
-        assertTrue(specialSkill.isAvailable());
+        boolean available = specialSkill.isAvailable();
+
+        assertTrue(available);
+    }
+
+    @Test
+    void triggerCooldown_whenCalled_setsCooldownRemainingToConfiguredTurns() {
+        SpecialSkill specialSkill = specialSkillWithCooldown(3);
 
         specialSkill.triggerCooldown();
 
         assertFalse(specialSkill.isAvailable());
         assertEquals(3, specialSkill.cooldownRemaining());
+    }
+
+    @Test
+    void advanceCooldown_whenCooldownIsActive_decrementsRemainingTurns() {
+        SpecialSkill specialSkill = specialSkillWithCooldown(3);
+        specialSkill.triggerCooldown();
 
         specialSkill.advanceCooldown();
-        specialSkill.advanceCooldown();
+
+        assertFalse(specialSkill.isAvailable());
+        assertEquals(2, specialSkill.cooldownRemaining());
+    }
+
+    @Test
+    void advanceCooldown_whenFinalTurnElapses_makesSkillAvailableAgain() {
+        SpecialSkill specialSkill = specialSkillWithCooldown(1);
+        specialSkill.triggerCooldown();
+
         specialSkill.advanceCooldown();
 
         assertTrue(specialSkill.isAvailable());
         assertEquals(0, specialSkill.cooldownRemaining());
+    }
+
+    private static SpecialSkill specialSkillWithCooldown(int cooldownTurns) {
+        return new SpecialSkill(new ShieldBashAction(), cooldownTurns);
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/StatTest.java
+++ b/src/test/java/sc2002/turnbased/domain/StatTest.java
@@ -9,13 +9,23 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 class StatTest {
     @Test
-    void adjustByReturnsUpdatedStat() {
-        assertEquals(new Stat(50), new Stat(40).adjustBy(10));
+    void adjustBy_whenAmountIsPositive_returnsUpdatedStat() {
+        Stat stat = new Stat(40);
+
+        Stat updatedStat = stat.adjustBy(10);
+
+        assertEquals(new Stat(50), updatedStat);
     }
 
     @Test
-    void statCannotBecomeNegative() {
+    void constructor_whenValueIsNegative_throwsIllegalArgumentException() {
         assertThrows(IllegalArgumentException.class, () -> new Stat(-1));
-        assertThrows(IllegalArgumentException.class, () -> new Stat(5).adjustBy(-6));
+    }
+
+    @Test
+    void adjustBy_whenResultWouldBeNegative_throwsIllegalArgumentException() {
+        Stat stat = new Stat(5);
+
+        assertThrows(IllegalArgumentException.class, () -> stat.adjustBy(-6));
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/StatusEffectRegistryTest.java
+++ b/src/test/java/sc2002/turnbased/domain/StatusEffectRegistryTest.java
@@ -12,24 +12,27 @@ import org.junit.jupiter.api.Test;
 @Tag("unit")
 class StatusEffectRegistryTest {
     @Test
-    void registryResolvesTurnBlockingAndExpiresEffect() {
+    void resolveTurnWindow_whenStunBlocksNextTurn_marksTurnBlockedAndExpiresEffect() {
         StatusEffectRegistry registry = new StatusEffectRegistry();
 
         registry.add(new StunStatusEffect(1));
+
         TurnWindow turnWindow = registry.resolveTurnWindow();
 
         assertTrue(turnWindow.isBlocked());
+        assertEquals("STUNNED", turnWindow.getBlockerLabel());
         assertEquals(List.of("Stun expires"), turnWindow.getNotes());
         assertEquals(List.of(), registry.activeStatusNames(true));
     }
 
     @Test
-    void registryAppliesDamageModifiersAndCleansUpExpiredEffects() {
+    void adjustIncomingDamage_whenSmokeBombBlocksEnemyAttack_returnsZeroAndExpiresEffect() {
         Warrior warrior = new Warrior();
         Goblin goblin = new Goblin("Goblin");
         List<String> notes = new ArrayList<>();
 
         warrior.addStatusEffect(new SmokeBombStatusEffect(1));
+
         int damage = warrior.statusEffects().adjustIncomingDamage(warrior, goblin, 15, notes);
 
         assertEquals(0, damage);

--- a/src/test/java/sc2002/turnbased/support/TestCombatantBuilder.java
+++ b/src/test/java/sc2002/turnbased/support/TestCombatantBuilder.java
@@ -1,0 +1,70 @@
+package sc2002.turnbased.support;
+
+import sc2002.turnbased.domain.CombatStats;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.HitPoints;
+import sc2002.turnbased.domain.Stat;
+
+public final class TestCombatantBuilder {
+    private String name = "Test Combatant";
+    private int currentHp = 100;
+    private int maxHp = 100;
+    private int attack = 40;
+    private int defense = 20;
+    private int speed = 30;
+
+    private TestCombatantBuilder() {
+    }
+
+    public static TestCombatantBuilder aCombatant() {
+        return new TestCombatantBuilder();
+    }
+
+    public TestCombatantBuilder named(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public TestCombatantBuilder withCurrentHp(int currentHp) {
+        this.currentHp = currentHp;
+        return this;
+    }
+
+    public TestCombatantBuilder withMaxHp(int maxHp) {
+        this.maxHp = maxHp;
+        return this;
+    }
+
+    public TestCombatantBuilder withAttack(int attack) {
+        this.attack = attack;
+        return this;
+    }
+
+    public TestCombatantBuilder withDefense(int defense) {
+        this.defense = defense;
+        return this;
+    }
+
+    public TestCombatantBuilder withSpeed(int speed) {
+        this.speed = speed;
+        return this;
+    }
+
+    public Combatant build() {
+        return new TestCombatant(
+            name,
+            CombatStats.of(
+                new HitPoints(currentHp, maxHp),
+                new Stat(attack),
+                new Stat(defense),
+                new Stat(speed)
+            )
+        );
+    }
+
+    private static final class TestCombatant extends Combatant {
+        private TestCombatant(String name, CombatStats baseStats) {
+            super(name, baseStats);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR refactors the domain unit tests to better match the testing standards documented in `project.md`.

Changes in this PR:
- refactor domain unit tests to follow strict Arrange / Act / Assert structure
- split multi-step lifecycle checks into single-behavior tests
- rename tests to describe business behavior instead of implementation details
- reduce brittle coupling to implicit class defaults where possible
- introduce a `TestCombatantBuilder` for clearer, named test setup in `CombatantTest`

## Why

The main goal is to make the test suite easier to read and safer to maintain.

In particular:
- `CombatantTest` no longer relies on opaque positional setup like `testCombatant(100, 100, 40, 20, 30)`
- HP-focused tests now only specify HP-related state instead of unrelated attack/defense/speed values
- test intent is clearer from the names and setup
- the suite is less fragile against future game-balance changes

## Scope

This PR only changes test code.

Updated tests:
- `HitPointsTest`
- `CombatStatsTest`
- `StatusEffectRegistryTest`
- `CombatantTest`
- `SpecialSkillTest`
- `StatTest`

Added test support:
- `TestCombatantBuilder`

## Verification

Ran:
- `mvn -q -Dtest='sc2002.turnbased.domain.*Test' test`
- `mvn -q -Dtest='sc2002.turnbased.domain.CombatantTest' test`
- `mvn -q test`
