### PR TITLE
Tianpok/status effect presentation separation

### DIFF
--- a/src/main/java/sc2002/turnbased/actions/ArcaneBlastAction.java
+++ b/src/main/java/sc2002/turnbased/actions/ArcaneBlastAction.java
@@ -3,8 +3,9 @@ package sc2002.turnbased.actions;
 import java.util.ArrayList;
 import java.util.List;
 
-import sc2002.turnbased.domain.status.ArcanePowerStatusEffect;
 import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.status.ArcanePowerStatusEffect;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
 import sc2002.turnbased.report.ActionEvent;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.report.NarrationEvent;
@@ -32,12 +33,12 @@ public class ArcaneBlastAction implements BattleAction {
             int hpBefore = enemy.getCurrentHp();
             enemy.receiveDamage(damage);
 
-            List<String> notes = new ArrayList<>();
+            List<sc2002.turnbased.domain.status.event.StatusEffectEvent> statusEffectEvents = List.of();
             if (!enemy.isAlive()) {
-                notes.add("ELIMINATED");
-                int attackBefore = actor.getAttack();
-                actor.addStatusEffect(new ArcanePowerStatusEffect(10));
-                notes.add(actor.getName() + " ATK: " + attackBefore + " -> " + actor.getAttack() + " (+10)");
+                try (StatusEffectObservationScope observation = actor.statusEffects().openObservation()) {
+                    actor.addStatusEffect(new ArcanePowerStatusEffect(10));
+                    statusEffectEvents = observation.observedEvents();
+                }
             }
 
             events.add(new ActionEvent(
@@ -49,7 +50,8 @@ public class ArcaneBlastAction implements BattleAction {
                 attackUsed,
                 enemy.getDefense(),
                 damage,
-                notes
+                !enemy.isAlive(),
+                statusEffectEvents
             ));
         }
 

--- a/src/main/java/sc2002/turnbased/actions/BasicAttackAction.java
+++ b/src/main/java/sc2002/turnbased/actions/BasicAttackAction.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.status.DamageAdjustment;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
 import sc2002.turnbased.report.ActionEvent;
 import sc2002.turnbased.report.BattleEvent;
 
@@ -17,26 +18,24 @@ public class BasicAttackAction implements BattleAction {
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
         int baseDamage = Math.max(0, actor.getAttack() - target.getDefense());
-        DamageAdjustment damageAdjustment = target.statusEffects().adjustIncomingDamage(target, actor, baseDamage);
-        List<String> notes = new ArrayList<>(damageAdjustment.notes());
-        int damage = damageAdjustment.damage();
-        int hpBefore = target.getCurrentHp();
-        target.receiveDamage(damage);
+        try (StatusEffectObservationScope observation = target.statusEffects().openObservation()) {
+            DamageAdjustment damageAdjustment = target.statusEffects().adjustIncomingDamage(target, actor, baseDamage);
+            int damage = damageAdjustment.damage();
+            int hpBefore = target.getCurrentHp();
+            target.receiveDamage(damage);
 
-        if (!target.isAlive()) {
-            notes.add("ELIMINATED");
+            return List.of(new ActionEvent(
+                actor.getName(),
+                getName(),
+                target.getName(),
+                hpBefore,
+                target.getCurrentHp(),
+                actor.getAttack(),
+                target.getDefense(),
+                damage,
+                !target.isAlive(),
+                observation.observedEvents()
+            ));
         }
-
-        return List.of(new ActionEvent(
-            actor.getName(),
-            getName(),
-            target.getName(),
-            hpBefore,
-            target.getCurrentHp(),
-            actor.getAttack(),
-            target.getDefense(),
-            damage,
-            notes
-        ));
     }
 }

--- a/src/main/java/sc2002/turnbased/actions/DefendAction.java
+++ b/src/main/java/sc2002/turnbased/actions/DefendAction.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.status.DefendStatusEffect;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.report.NarrationEvent;
+import sc2002.turnbased.report.StatusEffectReportEvent;
 
 public class DefendAction implements BattleAction {
     @Override
@@ -20,9 +22,12 @@ public class DefendAction implements BattleAction {
 
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
-        actor.addStatusEffect(new DefendStatusEffect(2));
-        return List.of(new NarrationEvent(
-            actor.getName() + " -> Defend: DEF +10 for current and next round"
-        ));
+        try (StatusEffectObservationScope observation = actor.statusEffects().openObservation()) {
+            actor.addStatusEffect(new DefendStatusEffect(2));
+            return List.of(
+                new NarrationEvent(actor.getName() + " -> Defend"),
+                new StatusEffectReportEvent(observation.observedEvents())
+            );
+        }
     }
 }

--- a/src/main/java/sc2002/turnbased/actions/ShieldBashAction.java
+++ b/src/main/java/sc2002/turnbased/actions/ShieldBashAction.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.status.DamageAdjustment;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
 import sc2002.turnbased.domain.status.StunStatusEffect;
 import sc2002.turnbased.report.ActionEvent;
 import sc2002.turnbased.report.BattleEvent;
@@ -18,29 +19,28 @@ public class ShieldBashAction implements BattleAction {
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
         int baseDamage = Math.max(0, actor.getAttack() - target.getDefense());
-        DamageAdjustment damageAdjustment = target.statusEffects().adjustIncomingDamage(target, actor, baseDamage);
-        List<String> notes = new ArrayList<>(damageAdjustment.notes());
-        int damage = damageAdjustment.damage();
-        int hpBefore = target.getCurrentHp();
-        target.receiveDamage(damage);
+        try (StatusEffectObservationScope observation = target.statusEffects().openObservation()) {
+            DamageAdjustment damageAdjustment = target.statusEffects().adjustIncomingDamage(target, actor, baseDamage);
+            int damage = damageAdjustment.damage();
+            int hpBefore = target.getCurrentHp();
+            target.receiveDamage(damage);
 
-        if (target.isAlive()) {
-            target.addStatusEffect(new StunStatusEffect(2));
-            notes.add(target.getName() + " STUNNED (2 turns)");
-        } else {
-            notes.add("ELIMINATED");
+            if (target.isAlive()) {
+                target.addStatusEffect(new StunStatusEffect(2));
+            }
+
+            return List.of(new ActionEvent(
+                actor.getName(),
+                getName(),
+                target.getName(),
+                hpBefore,
+                target.getCurrentHp(),
+                actor.getAttack(),
+                target.getDefense(),
+                damage,
+                !target.isAlive(),
+                observation.observedEvents()
+            ));
         }
-
-        return List.of(new ActionEvent(
-            actor.getName(),
-            getName(),
-            target.getName(),
-            hpBefore,
-            target.getCurrentHp(),
-            actor.getAttack(),
-            target.getDefense(),
-            damage,
-            notes
-        ));
     }
 }

--- a/src/main/java/sc2002/turnbased/actions/UseSmokeBombAction.java
+++ b/src/main/java/sc2002/turnbased/actions/UseSmokeBombAction.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
 import sc2002.turnbased.domain.status.SmokeBombStatusEffect;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.report.NarrationEvent;
+import sc2002.turnbased.report.StatusEffectReportEvent;
 
 public class UseSmokeBombAction implements BattleAction {
     @Override
@@ -22,9 +24,12 @@ public class UseSmokeBombAction implements BattleAction {
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
         context.getInventory().use(ItemType.SMOKE_BOMB);
-        actor.addStatusEffect(new SmokeBombStatusEffect(2));
-        return List.of(new NarrationEvent(
-            actor.getName() + " -> Item -> Smoke Bomb used: enemy attacks deal 0 damage for the next 2 enemy attacks"
-        ));
+        try (StatusEffectObservationScope observation = actor.statusEffects().openObservation()) {
+            actor.addStatusEffect(new SmokeBombStatusEffect(2));
+            return List.of(
+                new NarrationEvent(actor.getName() + " -> Item -> Smoke Bomb used"),
+                new StatusEffectReportEvent(observation.observedEvents())
+            );
+        }
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/Combatant.java
+++ b/src/main/java/sc2002/turnbased/domain/Combatant.java
@@ -10,12 +10,13 @@ public abstract class Combatant {
     private final String name;
     private final CombatStats baseStats;
     private HitPoints hitPoints;
-    private final StatusEffectRegistry statusEffectRegistry = new StatusEffectRegistry();
+    private final StatusEffectRegistry statusEffectRegistry;
 
-    protected Combatant(String name, HitPoints baseHitPoints, CombatStats baseStats) {
+    protected Combatant(String name, HitPoints baseHitPoints, CombatStats baseStats, StatusEffectRegistry statusEffectRegistry) {
         this.name = Objects.requireNonNull(name, "name");
         this.hitPoints = Objects.requireNonNull(baseHitPoints, "baseHitPoints");
         this.baseStats = Objects.requireNonNull(baseStats, "baseStats");
+        this.statusEffectRegistry = Objects.requireNonNull(statusEffectRegistry, "statusEffectRegistry");
     }
 
     public String getName() {
@@ -67,7 +68,7 @@ public abstract class Combatant {
     }
 
     public void addStatusEffect(StatusEffect statusEffect) {
-        statusEffectRegistry.add(statusEffect);
+        statusEffectRegistry.add(this, statusEffect);
     }
 
     public StatusEffectRegistry statusEffects() {
@@ -75,10 +76,10 @@ public abstract class Combatant {
     }
 
     public List<String> getActiveStatusNames() {
-        return statusEffectRegistry.activeStatusNames(isAlive());
+        return statusEffectRegistry.activeStatusNames(name, isAlive());
     }
 
     private CombatStats effectiveStats() {
-        return statusEffectRegistry.apply(baseStats);
+        return statusEffectRegistry.apply(name, baseStats);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/CombatantFactory.java
+++ b/src/main/java/sc2002/turnbased/domain/CombatantFactory.java
@@ -1,0 +1,10 @@
+package sc2002.turnbased.domain;
+
+import sc2002.turnbased.engine.EnemyType;
+import sc2002.turnbased.engine.PlayerType;
+
+public interface CombatantFactory {
+    PlayerCharacter createPlayer(PlayerType playerType);
+
+    EnemyCombatant createEnemy(EnemyType enemyType, String name);
+}

--- a/src/main/java/sc2002/turnbased/domain/DefaultCombatantFactory.java
+++ b/src/main/java/sc2002/turnbased/domain/DefaultCombatantFactory.java
@@ -1,0 +1,49 @@
+package sc2002.turnbased.domain;
+
+import java.util.Objects;
+
+import sc2002.turnbased.actions.BattleAction;
+import sc2002.turnbased.domain.status.StatusEffectRegistryFactory;
+import sc2002.turnbased.engine.EnemyType;
+import sc2002.turnbased.engine.PlayerType;
+
+public class DefaultCombatantFactory implements CombatantFactory {
+    private final StatusEffectRegistryFactory statusEffectRegistryFactory;
+    private final BattleAction basicAttackAction;
+    private final BattleAction shieldBashAction;
+    private final BattleAction arcaneBlastAction;
+
+    public DefaultCombatantFactory(
+        StatusEffectRegistryFactory statusEffectRegistryFactory,
+        BattleAction basicAttackAction,
+        BattleAction shieldBashAction,
+        BattleAction arcaneBlastAction
+    ) {
+        this.statusEffectRegistryFactory = Objects.requireNonNull(statusEffectRegistryFactory, "statusEffectRegistryFactory");
+        this.basicAttackAction = Objects.requireNonNull(basicAttackAction, "basicAttackAction");
+        this.shieldBashAction = Objects.requireNonNull(shieldBashAction, "shieldBashAction");
+        this.arcaneBlastAction = Objects.requireNonNull(arcaneBlastAction, "arcaneBlastAction");
+    }
+
+    @Override
+    public PlayerCharacter createPlayer(PlayerType playerType) {
+        return switch (Objects.requireNonNull(playerType, "playerType")) {
+            case WARRIOR -> new Warrior(
+                statusEffectRegistryFactory.create(),
+                new SpecialSkill(shieldBashAction, 3)
+            );
+            case WIZARD -> new Wizard(
+                statusEffectRegistryFactory.create(),
+                new SpecialSkill(arcaneBlastAction, 3)
+            );
+        };
+    }
+
+    @Override
+    public EnemyCombatant createEnemy(EnemyType enemyType, String name) {
+        return switch (Objects.requireNonNull(enemyType, "enemyType")) {
+            case GOBLIN -> new Goblin(name, statusEffectRegistryFactory.create(), basicAttackAction);
+            case WOLF -> new Wolf(name, statusEffectRegistryFactory.create(), basicAttackAction);
+        };
+    }
+}

--- a/src/main/java/sc2002/turnbased/domain/EnemyCombatant.java
+++ b/src/main/java/sc2002/turnbased/domain/EnemyCombatant.java
@@ -1,17 +1,24 @@
 package sc2002.turnbased.domain;
 
 import sc2002.turnbased.actions.ActionExecutionContext;
-import sc2002.turnbased.actions.BasicAttackAction;
 import sc2002.turnbased.actions.BattleAction;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
 
 public abstract class EnemyCombatant extends Combatant {
-    private static final BattleAction BASIC_ATTACK = new BasicAttackAction();
+    private final BattleAction basicAttackAction;
 
-    protected EnemyCombatant(String name, HitPoints baseHitPoints, CombatStats baseStats) {
-        super(name, baseHitPoints, baseStats);
+    protected EnemyCombatant(
+        String name,
+        HitPoints baseHitPoints,
+        CombatStats baseStats,
+        StatusEffectRegistry statusEffectRegistry,
+        BattleAction basicAttackAction
+    ) {
+        super(name, baseHitPoints, baseStats, statusEffectRegistry);
+        this.basicAttackAction = basicAttackAction;
     }
 
     public BattleAction selectAction(ActionExecutionContext context) {
-        return BASIC_ATTACK;
+        return basicAttackAction;
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/Goblin.java
+++ b/src/main/java/sc2002/turnbased/domain/Goblin.java
@@ -1,5 +1,8 @@
 package sc2002.turnbased.domain;
 
+import sc2002.turnbased.actions.BattleAction;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
+
 public class Goblin extends EnemyCombatant {
     private static final HitPoints GOBLIN_HIT_POINTS = HitPoints.full(55);
     private static final CombatStats GOBLIN_STATS = CombatStats.builder()
@@ -8,7 +11,7 @@ public class Goblin extends EnemyCombatant {
         .speed(25)
         .build();
 
-    public Goblin(String name) {
-        super(name, GOBLIN_HIT_POINTS, GOBLIN_STATS);
+    public Goblin(String name, StatusEffectRegistry statusEffectRegistry, BattleAction basicAttackAction) {
+        super(name, GOBLIN_HIT_POINTS, GOBLIN_STATS, statusEffectRegistry, basicAttackAction);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/PlayerCharacter.java
+++ b/src/main/java/sc2002/turnbased/domain/PlayerCharacter.java
@@ -2,11 +2,19 @@ package sc2002.turnbased.domain;
 
 import java.util.Objects;
 
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
+
 public abstract class PlayerCharacter extends Combatant {
     private final SpecialSkill specialSkill;
 
-    protected PlayerCharacter(String name, HitPoints baseHitPoints, CombatStats baseStats, SpecialSkill specialSkill) {
-        super(name, baseHitPoints, baseStats);
+    protected PlayerCharacter(
+        String name,
+        HitPoints baseHitPoints,
+        CombatStats baseStats,
+        StatusEffectRegistry statusEffectRegistry,
+        SpecialSkill specialSkill
+    ) {
+        super(name, baseHitPoints, baseStats, statusEffectRegistry);
         this.specialSkill = Objects.requireNonNull(specialSkill, "specialSkill");
     }
 

--- a/src/main/java/sc2002/turnbased/domain/Warrior.java
+++ b/src/main/java/sc2002/turnbased/domain/Warrior.java
@@ -1,6 +1,6 @@
 package sc2002.turnbased.domain;
 
-import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
 
 public class Warrior extends PlayerCharacter {
     private static final HitPoints WARRIOR_HIT_POINTS = HitPoints.full(260);
@@ -10,7 +10,7 @@ public class Warrior extends PlayerCharacter {
         .speed(30)
         .build();
 
-    public Warrior() {
-        super("Warrior", WARRIOR_HIT_POINTS, WARRIOR_STATS, new SpecialSkill(new ShieldBashAction(), 3));
+    public Warrior(StatusEffectRegistry statusEffectRegistry, SpecialSkill specialSkill) {
+        super("Warrior", WARRIOR_HIT_POINTS, WARRIOR_STATS, statusEffectRegistry, specialSkill);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/Wizard.java
+++ b/src/main/java/sc2002/turnbased/domain/Wizard.java
@@ -1,6 +1,6 @@
 package sc2002.turnbased.domain;
 
-import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
 
 public class Wizard extends PlayerCharacter {
     private static final HitPoints WIZARD_HIT_POINTS = HitPoints.full(200);
@@ -10,7 +10,7 @@ public class Wizard extends PlayerCharacter {
         .speed(20)
         .build();
 
-    public Wizard() {
-        super("Wizard", WIZARD_HIT_POINTS, WIZARD_STATS, new SpecialSkill(new ArcaneBlastAction(), 3));
+    public Wizard(StatusEffectRegistry statusEffectRegistry, SpecialSkill specialSkill) {
+        super("Wizard", WIZARD_HIT_POINTS, WIZARD_STATS, statusEffectRegistry, specialSkill);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/Wolf.java
+++ b/src/main/java/sc2002/turnbased/domain/Wolf.java
@@ -1,5 +1,8 @@
 package sc2002.turnbased.domain;
 
+import sc2002.turnbased.actions.BattleAction;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
+
 public class Wolf extends EnemyCombatant {
     private static final HitPoints WOLF_HIT_POINTS = HitPoints.full(40);
     private static final CombatStats WOLF_STATS = CombatStats.builder()
@@ -8,7 +11,7 @@ public class Wolf extends EnemyCombatant {
         .speed(35)
         .build();
 
-    public Wolf(String name) {
-        super(name, WOLF_HIT_POINTS, WOLF_STATS);
+    public Wolf(String name, StatusEffectRegistry statusEffectRegistry, BattleAction basicAttackAction) {
+        super(name, WOLF_HIT_POINTS, WOLF_STATS, statusEffectRegistry, basicAttackAction);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/status/ArcanePowerStatusEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/ArcanePowerStatusEffect.java
@@ -2,6 +2,7 @@ package sc2002.turnbased.domain.status;
 
 import sc2002.turnbased.domain.CombatStats;
 import sc2002.turnbased.domain.StatType;
+import sc2002.turnbased.domain.status.event.ArcanePowerAppliedEvent;
 
 public class ArcanePowerStatusEffect implements StatusEffect, StatModifierEffect, MergeableStatusEffect {
     private final int attackBonus;
@@ -14,8 +15,18 @@ public class ArcanePowerStatusEffect implements StatusEffect, StatModifierEffect
     }
 
     @Override
+    public StatusEffectKind kind() {
+        return StatusEffectKind.ARCANE_POWER;
+    }
+
+    @Override
     public String name() {
         return "ARCANE POWER +" + attackBonus;
+    }
+
+    @Override
+    public void onRegistered(String ownerName, StatusEffectEventPublisher eventPublisher) {
+        eventPublisher.publish(new ArcanePowerAppliedEvent(ownerName, attackBonus));
     }
 
     @Override

--- a/src/main/java/sc2002/turnbased/domain/status/DamageAdjustment.java
+++ b/src/main/java/sc2002/turnbased/domain/status/DamageAdjustment.java
@@ -1,14 +1,7 @@
 package sc2002.turnbased.domain.status;
 
-import java.util.List;
-import java.util.Objects;
-
-public record DamageAdjustment(int damage, List<String> notes) {
-    public DamageAdjustment {
-        notes = List.copyOf(Objects.requireNonNull(notes, "notes"));
-    }
-
+public record DamageAdjustment(int damage) {
     public static DamageAdjustment unchanged(int damage) {
-        return new DamageAdjustment(damage, List.of());
+        return new DamageAdjustment(damage);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/status/DefaultStatusEffectRegistryFactory.java
+++ b/src/main/java/sc2002/turnbased/domain/status/DefaultStatusEffectRegistryFactory.java
@@ -1,0 +1,8 @@
+package sc2002.turnbased.domain.status;
+
+public class DefaultStatusEffectRegistryFactory implements StatusEffectRegistryFactory {
+    @Override
+    public StatusEffectRegistry create() {
+        return new StatusEffectRegistry(new StatusEffectEventPublisher());
+    }
+}

--- a/src/main/java/sc2002/turnbased/domain/status/DefendStatusEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/DefendStatusEffect.java
@@ -2,6 +2,7 @@ package sc2002.turnbased.domain.status;
 
 import sc2002.turnbased.domain.CombatStats;
 import sc2002.turnbased.domain.StatType;
+import sc2002.turnbased.domain.status.event.DefendAppliedEvent;
 
 public class DefendStatusEffect implements StatusEffect, StatModifierEffect {
     private int roundsRemaining;
@@ -11,8 +12,18 @@ public class DefendStatusEffect implements StatusEffect, StatModifierEffect {
     }
 
     @Override
+    public StatusEffectKind kind() {
+        return StatusEffectKind.DEFEND;
+    }
+
+    @Override
     public String name() {
         return "DEFENDING";
+    }
+
+    @Override
+    public void onRegistered(String ownerName, StatusEffectEventPublisher eventPublisher) {
+        eventPublisher.publish(new DefendAppliedEvent(ownerName, 10, roundsRemaining));
     }
 
     @Override

--- a/src/main/java/sc2002/turnbased/domain/status/IncomingDamageModifierEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/IncomingDamageModifierEffect.java
@@ -3,5 +3,10 @@ package sc2002.turnbased.domain.status;
 import sc2002.turnbased.domain.Combatant;
 
 public interface IncomingDamageModifierEffect {
-    DamageAdjustment adjustIncomingDamage(Combatant owner, Combatant attacker, int damage);
+    DamageAdjustment adjustIncomingDamage(
+        Combatant owner,
+        Combatant attacker,
+        int damage,
+        StatusEffectEventPublisher eventPublisher
+    );
 }

--- a/src/main/java/sc2002/turnbased/domain/status/SmokeBombStatusEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/SmokeBombStatusEffect.java
@@ -1,8 +1,8 @@
 package sc2002.turnbased.domain.status;
 
-import java.util.List;
-
 import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
+import sc2002.turnbased.domain.status.event.SmokeBombAppliedEvent;
 
 public class SmokeBombStatusEffect implements StatusEffect, IncomingDamageModifierEffect {
     private int protectedEnemyAttacksRemaining;
@@ -12,23 +12,38 @@ public class SmokeBombStatusEffect implements StatusEffect, IncomingDamageModifi
     }
 
     @Override
+    public StatusEffectKind kind() {
+        return StatusEffectKind.SMOKE_BOMB;
+    }
+
+    @Override
     public String name() {
         return "SMOKE BOMB";
     }
 
     @Override
-    public DamageAdjustment adjustIncomingDamage(Combatant owner, Combatant attacker, int damage) {
+    public void onRegistered(String ownerName, StatusEffectEventPublisher eventPublisher) {
+        eventPublisher.publish(new SmokeBombAppliedEvent(ownerName, protectedEnemyAttacksRemaining));
+    }
+
+    @Override
+    public DamageAdjustment adjustIncomingDamage(
+        Combatant owner,
+        Combatant attacker,
+        int damage,
+        StatusEffectEventPublisher eventPublisher
+    ) {
         if (protectedEnemyAttacksRemaining <= 0 || attacker == owner) {
             return DamageAdjustment.unchanged(damage);
         }
 
         protectedEnemyAttacksRemaining--;
-        List<String> notes = new java.util.ArrayList<>();
-        notes.add("Smoke Bomb active");
-        if (protectedEnemyAttacksRemaining == 0) {
-            notes.add("Smoke Bomb effect expires");
-        }
-        return new DamageAdjustment(0, notes);
+        eventPublisher.publish(new SmokeBombActivatedEvent(
+            owner.getName(),
+            attacker.getName(),
+            protectedEnemyAttacksRemaining
+        ));
+        return new DamageAdjustment(0);
     }
 
     @Override

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffect.java
@@ -1,7 +1,18 @@
 package sc2002.turnbased.domain.status;
 
+import sc2002.turnbased.domain.status.event.StatusEffectExpiredEvent;
+
 public interface StatusEffect {
+    StatusEffectKind kind();
+
     String name();
+
+    default void onRegistered(String ownerName, StatusEffectEventPublisher eventPublisher) {
+    }
+
+    default void onExpired(String ownerName, StatusEffectEventPublisher eventPublisher) {
+        eventPublisher.publish(new StatusEffectExpiredEvent(ownerName, kind()));
+    }
 
     default void onRoundCompleted() {
     }

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffectEventPublisher.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffectEventPublisher.java
@@ -1,0 +1,26 @@
+package sc2002.turnbased.domain.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+
+public class StatusEffectEventPublisher {
+    private final List<StatusEffectObserver> observers = new ArrayList<>();
+
+    public void addObserver(StatusEffectObserver observer) {
+        observers.add(Objects.requireNonNull(observer, "observer"));
+    }
+
+    public void removeObserver(StatusEffectObserver observer) {
+        observers.remove(observer);
+    }
+
+    public void publish(StatusEffectEvent event) {
+        StatusEffectEvent publishedEvent = Objects.requireNonNull(event, "event");
+        for (StatusEffectObserver observer : List.copyOf(observers)) {
+            observer.onStatusEffectEvent(publishedEvent);
+        }
+    }
+}

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffectKind.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffectKind.java
@@ -1,0 +1,8 @@
+package sc2002.turnbased.domain.status;
+
+public enum StatusEffectKind {
+    ARCANE_POWER,
+    DEFEND,
+    SMOKE_BOMB,
+    STUN
+}

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffectObservationScope.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffectObservationScope.java
@@ -1,0 +1,40 @@
+package sc2002.turnbased.domain.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+
+/**
+ * This is a design pattern
+ * <a href="https://refactoring.guru/design-patterns/observer">Observer Design Pattern</a>
+ */
+public class StatusEffectObservationScope implements AutoCloseable, StatusEffectObserver {
+    private final StatusEffectEventPublisher eventPublisher;
+    private final List<StatusEffectEvent> observedEvents = new ArrayList<>();
+    private boolean closed;
+
+    public StatusEffectObservationScope(StatusEffectEventPublisher eventPublisher) {
+        this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+        this.eventPublisher.addObserver(this);
+    }
+
+    @Override
+    public void onStatusEffectEvent(StatusEffectEvent event) {
+        observedEvents.add(Objects.requireNonNull(event, "event"));
+    }
+
+    public List<StatusEffectEvent> observedEvents() {
+        return List.copyOf(observedEvents);
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        eventPublisher.removeObserver(this);
+        closed = true;
+    }
+}

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffectObserver.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffectObserver.java
@@ -1,0 +1,7 @@
+package sc2002.turnbased.domain.status;
+
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+
+public interface StatusEffectObserver {
+    void onStatusEffectEvent(StatusEffectEvent event);
+}

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffectRegistry.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffectRegistry.java
@@ -10,82 +10,92 @@ import sc2002.turnbased.domain.Combatant;
 
 public class StatusEffectRegistry {
     private final List<StatusEffect> effects = new ArrayList<>();
+    private final StatusEffectEventPublisher eventPublisher;
 
-    public void add(StatusEffect statusEffect) {
+    public StatusEffectRegistry(StatusEffectEventPublisher eventPublisher) {
+        this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher");
+    }
+
+    public void add(Combatant owner, StatusEffect statusEffect) {
+        Combatant effectOwner = Objects.requireNonNull(owner, "owner");
         StatusEffect effectToAdd = Objects.requireNonNull(statusEffect, "statusEffect");
-        pruneExpiredEffects();
+        pruneExpiredEffects(effectOwner);
 
         for (int index = 0; index < effects.size(); index++) {
             StatusEffect existingEffect = effects.get(index);
             if (existingEffect instanceof MergeableStatusEffect mergeableEffect
                 && mergeableEffect.canMergeWith(effectToAdd)) {
-                effects.set(index, mergeableEffect.merge(effectToAdd));
+                StatusEffect mergedEffect = mergeableEffect.merge(effectToAdd);
+                effects.set(index, mergedEffect);
+                mergedEffect.onRegistered(effectOwner.getName(), eventPublisher);
                 return;
             }
             if (effectToAdd instanceof MergeableStatusEffect mergeableEffectToAdd
                 && mergeableEffectToAdd.canMergeWith(existingEffect)) {
-                effects.set(index, mergeableEffectToAdd.merge(existingEffect));
+                StatusEffect mergedEffect = mergeableEffectToAdd.merge(existingEffect);
+                effects.set(index, mergedEffect);
+                mergedEffect.onRegistered(effectOwner.getName(), eventPublisher);
                 return;
             }
         }
 
         effects.add(effectToAdd);
+        effectToAdd.onRegistered(effectOwner.getName(), eventPublisher);
     }
 
     public DamageAdjustment adjustIncomingDamage(Combatant owner, Combatant attacker, int damage) {
-        List<String> notes = new ArrayList<>();
         Iterator<StatusEffect> iterator = effects.iterator();
         while (iterator.hasNext()) {
             StatusEffect statusEffect = iterator.next();
             if (statusEffect instanceof IncomingDamageModifierEffect modifierEffect) {
-                DamageAdjustment adjustment = modifierEffect.adjustIncomingDamage(owner, attacker, damage);
+                DamageAdjustment adjustment = modifierEffect.adjustIncomingDamage(owner, attacker, damage, eventPublisher);
                 damage = adjustment.damage();
-                notes.addAll(adjustment.notes());
             }
             if (statusEffect.isExpired()) {
+                statusEffect.onExpired(owner.getName(), eventPublisher);
                 iterator.remove();
             }
         }
-        return new DamageAdjustment(damage, notes);
+        return new DamageAdjustment(damage);
     }
 
-    public TurnWindow resolveTurnWindow() {
+    public TurnWindow resolveTurnWindow(Combatant owner) {
         boolean blocked = false;
         String blockerLabel = null;
-        List<String> notes = new ArrayList<>();
 
         Iterator<StatusEffect> iterator = effects.iterator();
         while (iterator.hasNext()) {
             StatusEffect statusEffect = iterator.next();
             if (statusEffect instanceof TurnInterferingEffect turnInterferingEffect) {
-                TurnEffectResolution resolution = turnInterferingEffect.onTurnOpportunity();
+                TurnEffectResolution resolution = turnInterferingEffect.onTurnOpportunity(owner, eventPublisher);
                 if (resolution.blocksAction() && blockerLabel == null) {
                     blocked = true;
                     blockerLabel = resolution.blockerLabel();
                 }
-                notes.addAll(resolution.notes());
             }
             if (statusEffect.isExpired()) {
+                statusEffect.onExpired(owner.getName(), eventPublisher);
                 iterator.remove();
             }
         }
 
-        return new TurnWindow(blocked, blockerLabel, notes);
+        return new TurnWindow(blocked, blockerLabel);
     }
 
-    public void onRoundCompleted() {
+    public void onRoundCompleted(Combatant owner) {
         Iterator<StatusEffect> iterator = effects.iterator();
         while (iterator.hasNext()) {
             StatusEffect statusEffect = iterator.next();
             statusEffect.onRoundCompleted();
             if (statusEffect.isExpired()) {
+                statusEffect.onExpired(owner.getName(), eventPublisher);
                 iterator.remove();
             }
         }
     }
 
-    public List<String> activeStatusNames(boolean ownerAlive) {
-        pruneExpiredEffects();
+    public List<String> activeStatusNames(String ownerName, boolean ownerAlive) {
+        pruneExpiredEffects(ownerName);
         if (!ownerAlive) {
             return List.of();
         }
@@ -97,8 +107,8 @@ public class StatusEffectRegistry {
         return names;
     }
 
-    public CombatStats apply(CombatStats stats) {
-        pruneExpiredEffects();
+    public CombatStats apply(String ownerName, CombatStats stats) {
+        pruneExpiredEffects(ownerName);
 
         CombatStats effectiveStats = Objects.requireNonNull(stats, "stats");
         for (StatusEffect statusEffect : effects) {
@@ -109,7 +119,22 @@ public class StatusEffectRegistry {
         return effectiveStats;
     }
 
-    private void pruneExpiredEffects() {
-        effects.removeIf(StatusEffect::isExpired);
+    public StatusEffectObservationScope openObservation() {
+        return new StatusEffectObservationScope(eventPublisher);
+    }
+
+    private void pruneExpiredEffects(Combatant owner) {
+        pruneExpiredEffects(owner.getName());
+    }
+
+    private void pruneExpiredEffects(String ownerName) {
+        Iterator<StatusEffect> iterator = effects.iterator();
+        while (iterator.hasNext()) {
+            StatusEffect statusEffect = iterator.next();
+            if (statusEffect.isExpired()) {
+                statusEffect.onExpired(ownerName, eventPublisher);
+                iterator.remove();
+            }
+        }
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/status/StatusEffectRegistryFactory.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StatusEffectRegistryFactory.java
@@ -1,0 +1,5 @@
+package sc2002.turnbased.domain.status;
+
+public interface StatusEffectRegistryFactory {
+    StatusEffectRegistry create();
+}

--- a/src/main/java/sc2002/turnbased/domain/status/StunStatusEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/StunStatusEffect.java
@@ -1,7 +1,7 @@
 package sc2002.turnbased.domain.status;
 
-import java.util.ArrayList;
-import java.util.List;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.status.event.StunAppliedEvent;
 
 public class StunStatusEffect implements StatusEffect, TurnInterferingEffect {
     private int blockedTurnsRemaining;
@@ -11,23 +11,29 @@ public class StunStatusEffect implements StatusEffect, TurnInterferingEffect {
     }
 
     @Override
+    public StatusEffectKind kind() {
+        return StatusEffectKind.STUN;
+    }
+
+    @Override
     public String name() {
         return "STUNNED";
     }
 
     @Override
-    public TurnEffectResolution onTurnOpportunity() {
+    public void onRegistered(String ownerName, StatusEffectEventPublisher eventPublisher) {
+        eventPublisher.publish(new StunAppliedEvent(ownerName, blockedTurnsRemaining));
+    }
+
+    @Override
+    public TurnEffectResolution onTurnOpportunity(Combatant owner, StatusEffectEventPublisher eventPublisher) {
         boolean blocksAction = blockedTurnsRemaining > 0;
         if (!blocksAction) {
             return TurnEffectResolution.allow();
         }
 
-        List<String> notes = new ArrayList<>();
         blockedTurnsRemaining--;
-        if (blockedTurnsRemaining == 0) {
-            notes.add("Stun expires");
-        }
-        return new TurnEffectResolution(blocksAction, name(), notes);
+        return new TurnEffectResolution(blocksAction, name());
     }
 
     @Override

--- a/src/main/java/sc2002/turnbased/domain/status/TurnEffectResolution.java
+++ b/src/main/java/sc2002/turnbased/domain/status/TurnEffectResolution.java
@@ -1,22 +1,16 @@
 package sc2002.turnbased.domain.status;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 public class TurnEffectResolution {
     private final boolean blocksAction;
     private final String blockerLabel;
-    private final List<String> notes;
 
-    public TurnEffectResolution(boolean blocksAction, String blockerLabel, List<String> notes) {
+    public TurnEffectResolution(boolean blocksAction, String blockerLabel) {
         this.blocksAction = blocksAction;
         this.blockerLabel = blockerLabel;
-        this.notes = new ArrayList<>(notes);
     }
 
     public static TurnEffectResolution allow() {
-        return new TurnEffectResolution(false, null, List.of());
+        return new TurnEffectResolution(false, null);
     }
 
     public boolean blocksAction() {
@@ -25,9 +19,5 @@ public class TurnEffectResolution {
 
     public String blockerLabel() {
         return blockerLabel;
-    }
-
-    public List<String> notes() {
-        return Collections.unmodifiableList(notes);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/status/TurnInterferingEffect.java
+++ b/src/main/java/sc2002/turnbased/domain/status/TurnInterferingEffect.java
@@ -1,7 +1,9 @@
 package sc2002.turnbased.domain.status;
 
+import sc2002.turnbased.domain.Combatant;
+
 public interface TurnInterferingEffect {
-    default TurnEffectResolution onTurnOpportunity() {
+    default TurnEffectResolution onTurnOpportunity(Combatant owner, StatusEffectEventPublisher eventPublisher) {
         return TurnEffectResolution.allow();
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/status/TurnWindow.java
+++ b/src/main/java/sc2002/turnbased/domain/status/TurnWindow.java
@@ -1,18 +1,12 @@
 package sc2002.turnbased.domain.status;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 public class TurnWindow {
     private final boolean blocked;
     private final String blockerLabel;
-    private final List<String> notes;
 
-    public TurnWindow(boolean blocked, String blockerLabel, List<String> notes) {
+    public TurnWindow(boolean blocked, String blockerLabel) {
         this.blocked = blocked;
         this.blockerLabel = blockerLabel;
-        this.notes = new ArrayList<>(notes);
     }
 
     public boolean isBlocked() {
@@ -21,9 +15,5 @@ public class TurnWindow {
 
     public String getBlockerLabel() {
         return blockerLabel;
-    }
-
-    public List<String> getNotes() {
-        return Collections.unmodifiableList(notes);
     }
 }

--- a/src/main/java/sc2002/turnbased/domain/status/event/ArcanePowerAppliedEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/ArcanePowerAppliedEvent.java
@@ -1,0 +1,4 @@
+package sc2002.turnbased.domain.status.event;
+
+public record ArcanePowerAppliedEvent(String ownerName, int totalAttackBonus) implements StatusEffectEvent {
+}

--- a/src/main/java/sc2002/turnbased/domain/status/event/DefendAppliedEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/DefendAppliedEvent.java
@@ -1,0 +1,4 @@
+package sc2002.turnbased.domain.status.event;
+
+public record DefendAppliedEvent(String ownerName, int defenseBonus, int roundsRemaining) implements StatusEffectEvent {
+}

--- a/src/main/java/sc2002/turnbased/domain/status/event/SmokeBombActivatedEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/SmokeBombActivatedEvent.java
@@ -1,0 +1,8 @@
+package sc2002.turnbased.domain.status.event;
+
+public record SmokeBombActivatedEvent(
+    String ownerName,
+    String attackerName,
+    int protectedEnemyAttacksRemaining
+) implements StatusEffectEvent {
+}

--- a/src/main/java/sc2002/turnbased/domain/status/event/SmokeBombAppliedEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/SmokeBombAppliedEvent.java
@@ -1,0 +1,4 @@
+package sc2002.turnbased.domain.status.event;
+
+public record SmokeBombAppliedEvent(String ownerName, int protectedEnemyAttacks) implements StatusEffectEvent {
+}

--- a/src/main/java/sc2002/turnbased/domain/status/event/StatusEffectEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/StatusEffectEvent.java
@@ -1,0 +1,6 @@
+package sc2002.turnbased.domain.status.event;
+
+public sealed interface StatusEffectEvent permits ArcanePowerAppliedEvent, DefendAppliedEvent, SmokeBombActivatedEvent,
+    SmokeBombAppliedEvent, StatusEffectExpiredEvent, StunAppliedEvent {
+    String ownerName();
+}

--- a/src/main/java/sc2002/turnbased/domain/status/event/StatusEffectExpiredEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/StatusEffectExpiredEvent.java
@@ -1,0 +1,6 @@
+package sc2002.turnbased.domain.status.event;
+
+import sc2002.turnbased.domain.status.StatusEffectKind;
+
+public record StatusEffectExpiredEvent(String ownerName, StatusEffectKind effectKind) implements StatusEffectEvent {
+}

--- a/src/main/java/sc2002/turnbased/domain/status/event/StunAppliedEvent.java
+++ b/src/main/java/sc2002/turnbased/domain/status/event/StunAppliedEvent.java
@@ -1,0 +1,4 @@
+package sc2002.turnbased.domain.status.event;
+
+public record StunAppliedEvent(String ownerName, int blockedTurnsRemaining) implements StatusEffectEvent {
+}

--- a/src/main/java/sc2002/turnbased/engine/BattleEngine.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleEngine.java
@@ -10,6 +10,7 @@ import sc2002.turnbased.domain.EnemyCombatant;
 import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
 import sc2002.turnbased.domain.status.TurnWindow;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.report.CombatantSummary;
@@ -99,15 +100,17 @@ public class BattleEngine implements ActionExecutionContext {
             player.getSpecialSkill().advanceCooldown();
         }
 
-        TurnWindow turnWindow = actor.statusEffects().resolveTurnWindow();
-        if (!actor.isAlive()) {
-            emit(new SkippedTurnEvent(actor.getName(), "ELIMINATED", turnWindow.getNotes()), battleEventListener);
-            return;
-        }
+        try (StatusEffectObservationScope observation = actor.statusEffects().openObservation()) {
+            TurnWindow turnWindow = actor.statusEffects().resolveTurnWindow(actor);
+            if (!actor.isAlive()) {
+                emit(new SkippedTurnEvent(actor.getName(), "ELIMINATED", observation.observedEvents()), battleEventListener);
+                return;
+            }
 
-        if (turnWindow.isBlocked()) {
-            emit(new SkippedTurnEvent(actor.getName(), turnWindow.getBlockerLabel(), turnWindow.getNotes()), battleEventListener);
-            return;
+            if (turnWindow.isBlocked()) {
+                emit(new SkippedTurnEvent(actor.getName(), turnWindow.getBlockerLabel(), observation.observedEvents()), battleEventListener);
+                return;
+            }
         }
 
         if (actor == player) {
@@ -210,9 +213,9 @@ public class BattleEngine implements ActionExecutionContext {
     }
 
     private void completeRound() {
-        player.statusEffects().onRoundCompleted();
+        player.statusEffects().onRoundCompleted(player);
         for (Combatant enemy : spawnedEnemies) {
-            enemy.statusEffects().onRoundCompleted();
+            enemy.statusEffects().onRoundCompleted(enemy);
         }
     }
 

--- a/src/main/java/sc2002/turnbased/engine/BattleSetupFactory.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleSetupFactory.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Map;
 
+import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.ItemType;
@@ -12,18 +13,23 @@ import sc2002.turnbased.domain.PlayerCharacter;
 
 public class BattleSetupFactory {
     private static final char[] LABELS = {'A', 'B', 'C', 'D', 'E', 'F'};
+    private final CombatantFactory combatantFactory;
+
+    public BattleSetupFactory(CombatantFactory combatantFactory) {
+        this.combatantFactory = Objects.requireNonNull(combatantFactory, "combatantFactory");
+    }
 
     public BattleSetup create(GameConfiguration configuration) {
-        PlayerCharacter player = configuration.playerType().createPlayer();
+        PlayerCharacter player = configuration.playerType().createPlayer(combatantFactory);
         Inventory inventory = createInventory(configuration.selectedItems());
 
         return switch (configuration.difficultyLevel()) {
             case EASY -> new BattleSetup(
                 player,
                 List.of(
-                    EnemyType.GOBLIN.create("Goblin A"),
-                    EnemyType.GOBLIN.create("Goblin B"),
-                    EnemyType.GOBLIN.create("Goblin C")
+                    EnemyType.GOBLIN.create("Goblin A", combatantFactory),
+                    EnemyType.GOBLIN.create("Goblin B", combatantFactory),
+                    EnemyType.GOBLIN.create("Goblin C", combatantFactory)
                 ),
                 List.of(),
                 inventory
@@ -31,25 +37,25 @@ public class BattleSetupFactory {
             case MEDIUM -> new BattleSetup(
                 player,
                 List.of(
-                    EnemyType.GOBLIN.create("Goblin"),
-                    EnemyType.WOLF.create("Wolf")
+                    EnemyType.GOBLIN.create("Goblin", combatantFactory),
+                    EnemyType.WOLF.create("Wolf", combatantFactory)
                 ),
                 List.of(
-                    EnemyType.WOLF.create("Wolf A"),
-                    EnemyType.WOLF.create("Wolf B")
+                    EnemyType.WOLF.create("Wolf A", combatantFactory),
+                    EnemyType.WOLF.create("Wolf B", combatantFactory)
                 ),
                 inventory
             );
             case HARD -> new BattleSetup(
                 player,
                 List.of(
-                    EnemyType.GOBLIN.create("Goblin A"),
-                    EnemyType.GOBLIN.create("Goblin B")
+                    EnemyType.GOBLIN.create("Goblin A", combatantFactory),
+                    EnemyType.GOBLIN.create("Goblin B", combatantFactory)
                 ),
                 List.of(
-                    EnemyType.GOBLIN.create("Goblin C"),
-                    EnemyType.WOLF.create("Wolf A"),
-                    EnemyType.WOLF.create("Wolf B")
+                    EnemyType.GOBLIN.create("Goblin C", combatantFactory),
+                    EnemyType.WOLF.create("Wolf A", combatantFactory),
+                    EnemyType.WOLF.create("Wolf B", combatantFactory)
                 ),
                 inventory
             );
@@ -57,7 +63,7 @@ public class BattleSetupFactory {
     }
 
     public BattleSetup createCustom(CustomGameConfiguration config) {
-        PlayerCharacter player = config.playerType().createPlayer();
+        PlayerCharacter player = config.playerType().createPlayer(combatantFactory);
         Inventory inventory = createInventory(config.selectedItems());
         return buildSetup(player, inventory, config.waves());
     }
@@ -89,7 +95,7 @@ public class BattleSetupFactory {
     private Combatant createEnemy(EnemyFactory enemyFactory, Map<EnemyFactory, Integer> nextLabelByFactory) {
         int nextIndex = nextLabelByFactory.getOrDefault(enemyFactory, 0);
         nextLabelByFactory.put(enemyFactory, nextIndex + 1);
-        return enemyFactory.create(formatEnemyName(enemyFactory, nextIndex));
+        return enemyFactory.create(formatEnemyName(enemyFactory, nextIndex), combatantFactory);
     }
 
     private String formatEnemyName(EnemyFactory enemyFactory, int enemyIndex) {

--- a/src/main/java/sc2002/turnbased/engine/EasyLevelSetup.java
+++ b/src/main/java/sc2002/turnbased/engine/EasyLevelSetup.java
@@ -2,14 +2,24 @@ package sc2002.turnbased.engine;
 
 import java.util.List;
 
+import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.DefaultCombatantFactory;
 import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.DefaultStatusEffectRegistryFactory;
 
 public final class EasyLevelSetup {
     private EasyLevelSetup() {
     }
 
     public static BattleSetup createWarriorPotionSmokeBombSetup() {
-        return new BattleSetupFactory().create(
+        return new BattleSetupFactory(new DefaultCombatantFactory(
+            new DefaultStatusEffectRegistryFactory(),
+            new BasicAttackAction(),
+            new ShieldBashAction(),
+            new ArcaneBlastAction()
+        )).create(
             new GameConfiguration(
                 PlayerType.WARRIOR,
                 DifficultyLevel.EASY,

--- a/src/main/java/sc2002/turnbased/engine/EnemyFactory.java
+++ b/src/main/java/sc2002/turnbased/engine/EnemyFactory.java
@@ -1,5 +1,6 @@
 package sc2002.turnbased.engine;
 
+import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.EnemyCombatant;
 
 public interface EnemyFactory {
@@ -9,7 +10,7 @@ public interface EnemyFactory {
 
     int getMaxPerWave();
 
-    EnemyCombatant create(String name);
+    EnemyCombatant create(String name, CombatantFactory combatantFactory);
 
     default String formatCount(int count) {
         return count + " " + (count == 1 ? getDisplayName() : getPluralDisplayName());

--- a/src/main/java/sc2002/turnbased/engine/EnemyType.java
+++ b/src/main/java/sc2002/turnbased/engine/EnemyType.java
@@ -1,33 +1,27 @@
 package sc2002.turnbased.engine;
 
-import java.util.function.Function;
-
+import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.EnemyCombatant;
-import sc2002.turnbased.domain.Goblin;
-import sc2002.turnbased.domain.Wolf;
 
 public enum EnemyType implements EnemyFactory {
-    GOBLIN("Goblin", "Goblins", 3, "Goblins (HP:55 ATK:35 DEF:15 SPD:25)", Goblin::new),
-    WOLF("Wolf", "Wolves", 3, "Wolves  (HP:40 ATK:45 DEF:5  SPD:35)", Wolf::new);
+    GOBLIN("Goblin", "Goblins", 3, "Goblins (HP:55 ATK:35 DEF:15 SPD:25)"),
+    WOLF("Wolf", "Wolves", 3, "Wolves  (HP:40 ATK:45 DEF:5  SPD:35)");
 
     private final String displayName;
     private final String pluralDisplayName;
     private final int maxPerWave;
     private final String configurationPrompt;
-    private final Function<String, EnemyCombatant> enemyFactory;
 
     EnemyType(
         String displayName,
         String pluralDisplayName,
         int maxPerWave,
-        String configurationPrompt,
-        Function<String, EnemyCombatant> enemyFactory
+        String configurationPrompt
     ) {
         this.displayName = displayName;
         this.pluralDisplayName = pluralDisplayName;
         this.maxPerWave = maxPerWave;
         this.configurationPrompt = configurationPrompt;
-        this.enemyFactory = enemyFactory;
     }
 
     @Override
@@ -50,7 +44,7 @@ public enum EnemyType implements EnemyFactory {
     }
 
     @Override
-    public EnemyCombatant create(String name) {
-        return enemyFactory.apply(name);
+    public EnemyCombatant create(String name, CombatantFactory combatantFactory) {
+        return combatantFactory.createEnemy(this, name);
     }
 }

--- a/src/main/java/sc2002/turnbased/engine/HardLevelSetup.java
+++ b/src/main/java/sc2002/turnbased/engine/HardLevelSetup.java
@@ -3,10 +3,15 @@ package sc2002.turnbased.engine;
 import java.util.List;
 import java.util.Objects;
 
+import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.DefaultCombatantFactory;
 import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.PlayerCharacter;
 import sc2002.turnbased.domain.Wizard;
+import sc2002.turnbased.domain.status.DefaultStatusEffectRegistryFactory;
 
 public final class HardLevelSetup {
     private HardLevelSetup() {
@@ -25,7 +30,12 @@ public final class HardLevelSetup {
                 selectedItems.add(itemType);
             }
         }
-        return new BattleSetupFactory().create(
+        return new BattleSetupFactory(new DefaultCombatantFactory(
+            new DefaultStatusEffectRegistryFactory(),
+            new BasicAttackAction(),
+            new ShieldBashAction(),
+            new ArcaneBlastAction()
+        )).create(
             new GameConfiguration(playerType, DifficultyLevel.HARD, selectedItems)
         );
     }

--- a/src/main/java/sc2002/turnbased/engine/MediumLevelSetup.java
+++ b/src/main/java/sc2002/turnbased/engine/MediumLevelSetup.java
@@ -2,14 +2,24 @@ package sc2002.turnbased.engine;
 
 import java.util.List;
 
+import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.DefaultCombatantFactory;
 import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.DefaultStatusEffectRegistryFactory;
 
 public final class MediumLevelSetup {
     private MediumLevelSetup() {
     }
 
     public static BattleSetup createWarriorPowerStonePotionSetup() {
-        return new BattleSetupFactory().create(
+        return new BattleSetupFactory(new DefaultCombatantFactory(
+            new DefaultStatusEffectRegistryFactory(),
+            new BasicAttackAction(),
+            new ShieldBashAction(),
+            new ArcaneBlastAction()
+        )).create(
             new GameConfiguration(
                 PlayerType.WARRIOR,
                 DifficultyLevel.MEDIUM,
@@ -19,7 +29,12 @@ public final class MediumLevelSetup {
     }
 
     public static BattleSetup createWizardPowerStonePotionSetup() {
-        return new BattleSetupFactory().create(
+        return new BattleSetupFactory(new DefaultCombatantFactory(
+            new DefaultStatusEffectRegistryFactory(),
+            new BasicAttackAction(),
+            new ShieldBashAction(),
+            new ArcaneBlastAction()
+        )).create(
             new GameConfiguration(
                 PlayerType.WIZARD,
                 DifficultyLevel.MEDIUM,

--- a/src/main/java/sc2002/turnbased/engine/PlayerType.java
+++ b/src/main/java/sc2002/turnbased/engine/PlayerType.java
@@ -1,23 +1,18 @@
 package sc2002.turnbased.engine;
 
-import java.util.function.Supplier;
-
+import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.PlayerCharacter;
-import sc2002.turnbased.domain.Warrior;
-import sc2002.turnbased.domain.Wizard;
 
 public enum PlayerType {
-    WARRIOR("Warrior", "Shield Bash", Warrior::new),
-    WIZARD("Wizard", "Arcane Blast", Wizard::new);
+    WARRIOR("Warrior", "Shield Bash"),
+    WIZARD("Wizard", "Arcane Blast");
 
     private final String displayName;
     private final String specialSkillName;
-    private final Supplier<PlayerCharacter> playerFactory;
 
-    PlayerType(String displayName, String specialSkillName, Supplier<PlayerCharacter> playerFactory) {
+    PlayerType(String displayName, String specialSkillName) {
         this.displayName = displayName;
         this.specialSkillName = specialSkillName;
-        this.playerFactory = playerFactory;
     }
 
     public String getDisplayName() {
@@ -28,7 +23,7 @@ public enum PlayerType {
         return specialSkillName;
     }
 
-    public PlayerCharacter createPlayer() {
-        return playerFactory.get();
+    public PlayerCharacter createPlayer(CombatantFactory combatantFactory) {
+        return combatantFactory.createPlayer(this);
     }
 }

--- a/src/main/java/sc2002/turnbased/report/ActionEvent.java
+++ b/src/main/java/sc2002/turnbased/report/ActionEvent.java
@@ -1,8 +1,9 @@
 package sc2002.turnbased.report;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
 
 public class ActionEvent implements BattleEvent {
     private final String actorName;
@@ -13,7 +14,8 @@ public class ActionEvent implements BattleEvent {
     private final int attackerAttack;
     private final int targetDefense;
     private final int damage;
-    private final List<String> notes;
+    private final boolean targetEliminated;
+    private final List<StatusEffectEvent> statusEffectEvents;
 
     public ActionEvent(
         String actorName,
@@ -24,7 +26,8 @@ public class ActionEvent implements BattleEvent {
         int attackerAttack,
         int targetDefense,
         int damage,
-        List<String> notes
+        boolean targetEliminated,
+        List<StatusEffectEvent> statusEffectEvents
     ) {
         this.actorName = actorName;
         this.actionName = actionName;
@@ -34,7 +37,8 @@ public class ActionEvent implements BattleEvent {
         this.attackerAttack = attackerAttack;
         this.targetDefense = targetDefense;
         this.damage = damage;
-        this.notes = new ArrayList<>(notes);
+        this.targetEliminated = targetEliminated;
+        this.statusEffectEvents = List.copyOf(Objects.requireNonNull(statusEffectEvents, "statusEffectEvents"));
     }
 
     public String getActorName() {
@@ -69,7 +73,11 @@ public class ActionEvent implements BattleEvent {
         return damage;
     }
 
-    public List<String> getNotes() {
-        return Collections.unmodifiableList(notes);
+    public boolean isTargetEliminated() {
+        return targetEliminated;
+    }
+
+    public List<StatusEffectEvent> getStatusEffectEvents() {
+        return statusEffectEvents;
     }
 }

--- a/src/main/java/sc2002/turnbased/report/SkippedTurnEvent.java
+++ b/src/main/java/sc2002/turnbased/report/SkippedTurnEvent.java
@@ -1,18 +1,19 @@
 package sc2002.turnbased.report;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
 
 public class SkippedTurnEvent implements BattleEvent {
     private final String combatantName;
     private final String reason;
-    private final List<String> notes;
+    private final List<StatusEffectEvent> statusEffectEvents;
 
-    public SkippedTurnEvent(String combatantName, String reason, List<String> notes) {
+    public SkippedTurnEvent(String combatantName, String reason, List<StatusEffectEvent> statusEffectEvents) {
         this.combatantName = combatantName;
         this.reason = reason;
-        this.notes = new ArrayList<>(notes);
+        this.statusEffectEvents = List.copyOf(Objects.requireNonNull(statusEffectEvents, "statusEffectEvents"));
     }
 
     public String getCombatantName() {
@@ -23,7 +24,7 @@ public class SkippedTurnEvent implements BattleEvent {
         return reason;
     }
 
-    public List<String> getNotes() {
-        return Collections.unmodifiableList(notes);
+    public List<StatusEffectEvent> getStatusEffectEvents() {
+        return statusEffectEvents;
     }
 }

--- a/src/main/java/sc2002/turnbased/report/StatusEffectReportEvent.java
+++ b/src/main/java/sc2002/turnbased/report/StatusEffectReportEvent.java
@@ -1,0 +1,12 @@
+package sc2002.turnbased.report;
+
+import java.util.List;
+import java.util.Objects;
+
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+
+public record StatusEffectReportEvent(List<StatusEffectEvent> statusEffectEvents) implements BattleEvent {
+    public StatusEffectReportEvent {
+        statusEffectEvents = List.copyOf(Objects.requireNonNull(statusEffectEvents, "statusEffectEvents"));
+    }
+}

--- a/src/main/java/sc2002/turnbased/ui/BattleConsoleFormatter.java
+++ b/src/main/java/sc2002/turnbased/ui/BattleConsoleFormatter.java
@@ -5,6 +5,14 @@ import java.util.List;
 import java.util.Map;
 
 import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.StatusEffectKind;
+import sc2002.turnbased.domain.status.event.ArcanePowerAppliedEvent;
+import sc2002.turnbased.domain.status.event.DefendAppliedEvent;
+import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
+import sc2002.turnbased.domain.status.event.SmokeBombAppliedEvent;
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+import sc2002.turnbased.domain.status.event.StatusEffectExpiredEvent;
+import sc2002.turnbased.domain.status.event.StunAppliedEvent;
 import sc2002.turnbased.report.ActionEvent;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.report.CombatantSummary;
@@ -12,6 +20,7 @@ import sc2002.turnbased.report.NarrationEvent;
 import sc2002.turnbased.report.RoundStartEvent;
 import sc2002.turnbased.report.RoundSummaryEvent;
 import sc2002.turnbased.report.SkippedTurnEvent;
+import sc2002.turnbased.report.StatusEffectReportEvent;
 
 public class BattleConsoleFormatter {
     public List<String> format(List<BattleEvent> events) {
@@ -33,6 +42,10 @@ public class BattleConsoleFormatter {
                 lines.add(formatSkippedTurn(skippedTurnEvent));
                 continue;
             }
+            if (event instanceof StatusEffectReportEvent statusEffectReportEvent) {
+                lines.addAll(formatStatusEffectEvents(statusEffectReportEvent.statusEffectEvents()));
+                continue;
+            }
             if (event instanceof RoundSummaryEvent roundSummaryEvent) {
                 lines.addAll(formatRoundSummary(roundSummaryEvent));
             }
@@ -52,7 +65,7 @@ public class BattleConsoleFormatter {
             .append(" -> ")
             .append(actionEvent.getHpAfter());
 
-        if (actionEvent.getNotes().contains("ELIMINATED")) {
+        if (actionEvent.isTargetEliminated()) {
             builder.append(" ELIMINATED");
         }
 
@@ -64,12 +77,7 @@ public class BattleConsoleFormatter {
             .append(actionEvent.getDamage())
             .append(")");
 
-        List<String> extraNotes = new ArrayList<>();
-        for (String note : actionEvent.getNotes()) {
-            if (!"ELIMINATED".equals(note)) {
-                extraNotes.add(note);
-            }
-        }
+        List<String> extraNotes = formatStatusEffectEvents(actionEvent.getStatusEffectEvents());
         if (!extraNotes.isEmpty()) {
             builder.append(" | ").append(String.join(" | ", extraNotes));
         }
@@ -90,11 +98,59 @@ public class BattleConsoleFormatter {
             builder.append("Turn skipped");
         }
 
-        if (!skippedTurnEvent.getNotes().isEmpty()) {
-            builder.append(" | ").append(String.join(" | ", skippedTurnEvent.getNotes()));
+        List<String> statusNotes = formatStatusEffectEvents(skippedTurnEvent.getStatusEffectEvents());
+        if (!statusNotes.isEmpty()) {
+            builder.append(" | ").append(String.join(" | ", statusNotes));
         }
 
         return builder.toString();
+    }
+
+    private List<String> formatStatusEffectEvents(List<StatusEffectEvent> statusEffectEvents) {
+        List<String> lines = new ArrayList<>();
+        for (StatusEffectEvent statusEffectEvent : statusEffectEvents) {
+            if (statusEffectEvent instanceof SmokeBombActivatedEvent) {
+                lines.add("Smoke Bomb active");
+                continue;
+            }
+            if (statusEffectEvent instanceof SmokeBombAppliedEvent smokeBombAppliedEvent) {
+                lines.add(smokeBombAppliedEvent.ownerName()
+                    + " gains Smoke Bomb protection for "
+                    + smokeBombAppliedEvent.protectedEnemyAttacks()
+                    + " enemy attacks");
+                continue;
+            }
+            if (statusEffectEvent instanceof StunAppliedEvent stunAppliedEvent) {
+                lines.add(stunAppliedEvent.ownerName() + " STUNNED (" + stunAppliedEvent.blockedTurnsRemaining() + " turns)");
+                continue;
+            }
+            if (statusEffectEvent instanceof DefendAppliedEvent defendAppliedEvent) {
+                lines.add(defendAppliedEvent.ownerName()
+                    + " DEF +"
+                    + defendAppliedEvent.defenseBonus()
+                    + " for "
+                    + defendAppliedEvent.roundsRemaining()
+                    + " rounds");
+                continue;
+            }
+            if (statusEffectEvent instanceof ArcanePowerAppliedEvent arcanePowerAppliedEvent) {
+                lines.add(arcanePowerAppliedEvent.ownerName() + " gains ARCANE POWER +" + arcanePowerAppliedEvent.totalAttackBonus());
+                continue;
+            }
+            if (statusEffectEvent instanceof StatusEffectExpiredEvent expiredEvent) {
+                lines.add(formatExpiration(expiredEvent.effectKind()));
+            }
+        }
+        return lines;
+    }
+
+    private String formatExpiration(StatusEffectKind statusEffectKind) {
+        return switch (statusEffectKind) {
+            case ARCANE_POWER -> "Arcane Power expires";
+            case DEFEND -> "Defend expires";
+            case SMOKE_BOMB -> "Smoke Bomb effect expires";
+            case STUN -> "Stun expires";
+        };
     }
 
     private List<String> formatRoundSummary(RoundSummaryEvent roundSummaryEvent) {

--- a/src/main/java/sc2002/turnbased/ui/ConsoleBattleUi.java
+++ b/src/main/java/sc2002/turnbased/ui/ConsoleBattleUi.java
@@ -5,12 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
+import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.PlayerCharacter;
-import sc2002.turnbased.domain.Warrior;
-import sc2002.turnbased.domain.Wizard;
 import sc2002.turnbased.engine.DifficultyLevel;
 import sc2002.turnbased.engine.EnemyCount;
 import sc2002.turnbased.engine.EnemyType;
@@ -21,18 +20,20 @@ import sc2002.turnbased.engine.WaveSpec;
 public class ConsoleBattleUi {
     private final Scanner scanner;
     private final PrintStream out;
+    private final CombatantFactory combatantFactory;
 
-    public ConsoleBattleUi(Scanner scanner, PrintStream out) {
+    public ConsoleBattleUi(Scanner scanner, PrintStream out, CombatantFactory combatantFactory) {
         this.scanner = scanner;
         this.out = out;
+        this.combatantFactory = combatantFactory;
     }
 
     public void showLoadingScreen() {
         out.println("=== SC2002 Turn-Based Combat Arena ===");
         out.println();
         out.println("Playable Classes:");
-        showPlayerPreview(PlayerType.WARRIOR, new Warrior());
-        showPlayerPreview(PlayerType.WIZARD, new Wizard());
+        showPlayerPreview(PlayerType.WARRIOR, PlayerType.WARRIOR.createPlayer(combatantFactory));
+        showPlayerPreview(PlayerType.WIZARD, PlayerType.WIZARD.createPlayer(combatantFactory));
         out.println();
         out.println("Usable Items:");
         for (ItemType itemType : ItemType.values()) {
@@ -41,7 +42,7 @@ public class ConsoleBattleUi {
         out.println();
         out.println("Enemy Types:");
         for (EnemyType enemyType : EnemyType.values()) {
-            showEnemyPreview(enemyType.create(enemyType.getDisplayName()));
+            showEnemyPreview(enemyType.create(enemyType.getDisplayName(), combatantFactory));
         }
         out.println();
         out.println("Difficulty Levels and Enemy Counts:");

--- a/src/main/java/sc2002/turnbased/ui/TurnBasedArenaCli.java
+++ b/src/main/java/sc2002/turnbased/ui/TurnBasedArenaCli.java
@@ -6,7 +6,13 @@ import java.util.Objects;
 import java.util.Scanner;
 import java.util.function.Supplier;
 
+import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.CombatantFactory;
+import sc2002.turnbased.domain.DefaultCombatantFactory;
 import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.DefaultStatusEffectRegistryFactory;
 import sc2002.turnbased.engine.BattleEngine;
 import sc2002.turnbased.engine.BattleEventListener;
 import sc2002.turnbased.engine.BattleSetup;
@@ -39,10 +45,16 @@ public class TurnBasedArenaCli {
     }
 
     public static void main(String[] args) {
-        ConsoleBattleUi ui = new ConsoleBattleUi(new Scanner(System.in), System.out);
+        CombatantFactory combatantFactory = new DefaultCombatantFactory(
+            new DefaultStatusEffectRegistryFactory(),
+            new BasicAttackAction(),
+            new ShieldBashAction(),
+            new ArcaneBlastAction()
+        );
+        ConsoleBattleUi ui = new ConsoleBattleUi(new Scanner(System.in), System.out, combatantFactory);
         new TurnBasedArenaCli(
             ui,
-            new BattleSetupFactory(),
+            new BattleSetupFactory(combatantFactory),
             new BattleConsoleFormatter(),
             new SpeedTurnOrderStrategy()
         ).run();

--- a/src/main/java/sc2002/turnbased/ui/gui/TurnBasedArenaGui.java
+++ b/src/main/java/sc2002/turnbased/ui/gui/TurnBasedArenaGui.java
@@ -27,7 +27,13 @@ import javax.swing.JTextArea;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 
+import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.CombatantFactory;
+import sc2002.turnbased.domain.DefaultCombatantFactory;
 import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.DefaultStatusEffectRegistryFactory;
 import sc2002.turnbased.engine.BattleEngine;
 import sc2002.turnbased.engine.BattleEventListener;
 import sc2002.turnbased.engine.BattleSetup;
@@ -57,7 +63,7 @@ public class TurnBasedArenaGui extends JFrame {
 
     private final JTextArea log = new JTextArea();
     private final BattleConsoleFormatter formatter = new BattleConsoleFormatter();
-    private final BattleSetupFactory setupFactory = new BattleSetupFactory();
+    private final BattleSetupFactory setupFactory;
     private final ExecutorService battleExecutor = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "battle-engine");
         t.setDaemon(true);
@@ -76,8 +82,9 @@ public class TurnBasedArenaGui extends JFrame {
     private JComboBox<ItemType> item1Box;
     private JComboBox<ItemType> item2Box;
 
-    public TurnBasedArenaGui() {
+    public TurnBasedArenaGui(BattleSetupFactory setupFactory) {
         super("SC2002 Turn-Based Arena");
+        this.setupFactory = setupFactory;
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         setLayout(new BorderLayout(8, 8));
 
@@ -345,7 +352,13 @@ public class TurnBasedArenaGui extends JFrame {
 
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> {
-            TurnBasedArenaGui w = new TurnBasedArenaGui();
+            CombatantFactory combatantFactory = new DefaultCombatantFactory(
+                new DefaultStatusEffectRegistryFactory(),
+                new BasicAttackAction(),
+                new ShieldBashAction(),
+                new ArcaneBlastAction()
+            );
+            TurnBasedArenaGui w = new TurnBasedArenaGui(new BattleSetupFactory(combatantFactory));
             w.setVisible(true);
             w.appendLog("SC2002 Turn-Based Combat Arena (GUI)\n"
                 + "Choose class, difficulty (or Custom Mode), two items, then Start battle.\n"

--- a/src/test/java/sc2002/turnbased/CustomGameModeVerifierTest.java
+++ b/src/test/java/sc2002/turnbased/CustomGameModeVerifierTest.java
@@ -32,9 +32,10 @@ import sc2002.turnbased.engine.WaveSpec;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.report.NarrationEvent;
 import sc2002.turnbased.report.RoundSummaryEvent;
+import sc2002.turnbased.support.TestDependencies;
 
 class CustomGameModeVerifierTest {
-    private final BattleSetupFactory battleSetupFactory = new BattleSetupFactory();
+    private final BattleSetupFactory battleSetupFactory = TestDependencies.battleSetupFactory();
 
     @Test
     @Tag("unit")

--- a/src/test/java/sc2002/turnbased/actions/ArcaneBlastActionTest.java
+++ b/src/test/java/sc2002/turnbased/actions/ArcaneBlastActionTest.java
@@ -10,15 +10,17 @@ import org.junit.jupiter.api.Test;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.Wizard;
+import sc2002.turnbased.domain.status.event.ArcanePowerAppliedEvent;
 import sc2002.turnbased.report.ActionEvent;
 import sc2002.turnbased.report.BattleEvent;
 import sc2002.turnbased.support.TestCombatantBuilder;
+import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class ArcaneBlastActionTest {
     @Test
     void execute_whenEnemiesAreEliminated_addsAttackBuffThroughStatusEffects() {
-        Wizard wizard = new Wizard();
+        Wizard wizard = TestDependencies.wizard();
         Combatant goblin = TestCombatantBuilder.aCombatant()
             .named("Goblin")
             .withCurrentHp(30)
@@ -39,8 +41,10 @@ class ArcaneBlastActionTest {
         assertEquals(70, wizard.getAttack());
         assertEquals(50, wizard.getBaseAttack());
         assertEquals(List.of("ARCANE POWER +20"), wizard.getActiveStatusNames());
-        assertEquals(List.of("ELIMINATED", "Wizard ATK: 50 -> 60 (+10)"), ((ActionEvent) events.get(1)).getNotes());
-        assertEquals(List.of("ELIMINATED", "Wizard ATK: 60 -> 70 (+10)"), ((ActionEvent) events.get(2)).getNotes());
+        assertEquals(true, ((ActionEvent) events.get(1)).isTargetEliminated());
+        assertEquals(List.of(new ArcanePowerAppliedEvent("Wizard", 10)), ((ActionEvent) events.get(1)).getStatusEffectEvents());
+        assertEquals(true, ((ActionEvent) events.get(2)).isTargetEliminated());
+        assertEquals(List.of(new ArcanePowerAppliedEvent("Wizard", 20)), ((ActionEvent) events.get(2)).getStatusEffectEvents());
     }
 
     private record TestActionExecutionContext(List<Combatant> livingEnemiesInTurnOrder) implements ActionExecutionContext {

--- a/src/test/java/sc2002/turnbased/domain/CombatantTest.java
+++ b/src/test/java/sc2002/turnbased/domain/CombatantTest.java
@@ -9,13 +9,14 @@ import org.junit.jupiter.api.Test;
 
 import sc2002.turnbased.domain.status.ArcanePowerStatusEffect;
 import sc2002.turnbased.domain.status.DefendStatusEffect;
+import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class CombatantTest {
     @Test
     void receiveDamageAndHeal_existingHitPoints_updatesHitPointsValueObject() {
         // arrange
-        Warrior warrior = new Warrior();
+        Warrior warrior = TestDependencies.warrior();
 
         // act
         warrior.receiveDamage(90);
@@ -31,7 +32,7 @@ class CombatantTest {
     @Test
     void addStatusEffect_arcanePowerBuffApplied_returnsBuffedAttackWithoutChangingBaseAttack() {
         // arrange
-        Wizard wizard = new Wizard();
+        Wizard wizard = TestDependencies.wizard();
 
         // act
         wizard.addStatusEffect(new ArcanePowerStatusEffect(10));
@@ -46,7 +47,7 @@ class CombatantTest {
     @Test
     void addStatusEffect_arcanePowerEffectsStack_returnsMergedAttackBonus() {
         // arrange
-        Warrior warrior = new Warrior();
+        Warrior warrior = TestDependencies.warrior();
 
         // act
         warrior.addStatusEffect(new ArcanePowerStatusEffect(10));
@@ -61,13 +62,13 @@ class CombatantTest {
     @Test
     void addStatusEffect_defendEffectActive_returnsTemporarilyIncreasedDefense() {
         // arrange
-        Warrior warrior = new Warrior();
+        Warrior warrior = TestDependencies.warrior();
         int defenseBeforeDefend = warrior.getDefense();
 
         // act
         warrior.addStatusEffect(new DefendStatusEffect(1));
         int defenseDuringDefend = warrior.getDefense();
-        warrior.statusEffects().onRoundCompleted();
+        warrior.statusEffects().onRoundCompleted(warrior);
         int defenseAfterDefend = warrior.getDefense();
 
         // assert

--- a/src/test/java/sc2002/turnbased/domain/status/SmokeBombStatusEffectTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/SmokeBombStatusEffectTest.java
@@ -1,5 +1,6 @@
 package sc2002.turnbased.domain.status;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,56 +12,122 @@ import org.junit.jupiter.api.Test;
 
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
+import sc2002.turnbased.support.FakeStatusEffectEventPublisher;
 import sc2002.turnbased.support.TestCombatantBuilder;
-import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class SmokeBombStatusEffectTest {
     @Test
     void adjustIncomingDamage_whenOwnerTargetsSelf_leavesDamageUnchanged() {
+        // Arrange
         Combatant owner = TestCombatantBuilder.aCombatant().build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
-        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
-        try (StatusEffectObservationScope observation = new StatusEffectObservationScope(eventPublisher)) {
-            DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, owner, 15, eventPublisher);
+        // Act
+        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, owner, 15, eventPublisher);
 
-            assertEquals("SMOKE BOMB", effect.name());
-            assertEquals(15, adjustment.damage());
-            assertEquals(List.of(), observation.observedEvents());
-            assertFalse(effect.isExpired());
-        }
+        // Assert
+        assertAll(
+            () -> assertEquals(15, adjustment.damage()),
+            () -> assertEquals(List.of(), eventPublisher.publishedEvents()),
+            () -> assertFalse(effect.isExpired())
+        );
+    }
+
+    @Test
+    void adjustIncomingDamage_whenEffectAlreadyExpired_leavesDamageUnchangedAndPublishesNoEvent() {
+        // Arrange
+        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        SmokeBombStatusEffect effect = new SmokeBombStatusEffect(0);
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
+
+        // Act
+        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
+
+        // Assert
+        assertAll(
+            () -> assertEquals(15, adjustment.damage()),
+            () -> assertEquals(List.of(), eventPublisher.publishedEvents()),
+            () -> assertTrue(effect.isExpired())
+        );
     }
 
     @Test
     void adjustIncomingDamage_whenEnemyAttackConsumesLastCharge_blocksDamageAndExpires() {
+        // Arrange
         Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
         Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(1);
-        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
-        try (StatusEffectObservationScope observation = new StatusEffectObservationScope(eventPublisher)) {
-            DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
+        // Act
+        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
 
-            assertEquals(0, adjustment.damage());
-            assertEquals(List.of(new SmokeBombActivatedEvent("Owner", "Attacker", 0)), observation.observedEvents());
-            assertTrue(effect.isExpired());
-        }
+        // Assert
+        assertAll(
+            () -> assertEquals(0, adjustment.damage()),
+            () -> assertTrue(effect.isExpired())
+        );
     }
 
     @Test
-    void adjustIncomingDamage_whenChargesRemain_afterFirstBlockEffectStaysActive() {
+    void adjustIncomingDamage_whenChargesRemainAfterFirstBlock_staysActive() {
+        // Arrange
         Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
         Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
-        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
-        try (StatusEffectObservationScope observation = new StatusEffectObservationScope(eventPublisher)) {
-            DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
+        // Act
+        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
 
-            assertEquals(0, adjustment.damage());
-            assertEquals(List.of(new SmokeBombActivatedEvent("Owner", "Attacker", 1)), observation.observedEvents());
-            assertFalse(effect.isExpired());
-        }
+        // Assert
+        assertAll(
+            () -> assertEquals(0, adjustment.damage()),
+            () -> assertFalse(effect.isExpired())
+        );
+    }
+
+    @Test
+    void adjustIncomingDamage_whenHitTwice_consumesChargesAcrossCalls() {
+        // Arrange
+        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
+
+        // Act
+        DamageAdjustment firstAdjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
+        DamageAdjustment secondAdjustment = effect.adjustIncomingDamage(owner, attacker, 20, eventPublisher);
+        DamageAdjustment thirdAdjustment = effect.adjustIncomingDamage(owner, attacker, 25, eventPublisher);
+
+        // Assert
+        assertAll(
+            () -> assertEquals(0, firstAdjustment.damage()),
+            () -> assertEquals(0, secondAdjustment.damage()),
+            () -> assertEquals(25, thirdAdjustment.damage()),
+            () -> assertTrue(effect.isExpired())
+        );
+    }
+
+    @Test
+    void adjustIncomingDamage_whenEnemyAttackIsBlocked_publishesActivationEvent() {
+        // Arrange
+        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
+        List<SmokeBombActivatedEvent> expectedEvents = List.of(new SmokeBombActivatedEvent("Owner", "Attacker", 1));
+
+        // Act
+        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
+
+        // Assert
+        assertAll(
+            () -> assertEquals(0, adjustment.damage()),
+            () -> assertEquals(expectedEvents, eventPublisher.publishedEvents())
+        );
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/status/SmokeBombStatusEffectTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/SmokeBombStatusEffectTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
 import sc2002.turnbased.support.TestCombatantBuilder;
+import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class SmokeBombStatusEffectTest {
@@ -18,13 +20,16 @@ class SmokeBombStatusEffectTest {
     void adjustIncomingDamage_whenOwnerTargetsSelf_leavesDamageUnchanged() {
         Combatant owner = TestCombatantBuilder.aCombatant().build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
+        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
 
-        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, owner, 15);
+        try (StatusEffectObservationScope observation = new StatusEffectObservationScope(eventPublisher)) {
+            DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, owner, 15, eventPublisher);
 
-        assertEquals("SMOKE BOMB", effect.name());
-        assertEquals(15, adjustment.damage());
-        assertEquals(List.of(), adjustment.notes());
-        assertFalse(effect.isExpired());
+            assertEquals("SMOKE BOMB", effect.name());
+            assertEquals(15, adjustment.damage());
+            assertEquals(List.of(), observation.observedEvents());
+            assertFalse(effect.isExpired());
+        }
     }
 
     @Test
@@ -32,12 +37,15 @@ class SmokeBombStatusEffectTest {
         Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
         Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(1);
+        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
 
-        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15);
+        try (StatusEffectObservationScope observation = new StatusEffectObservationScope(eventPublisher)) {
+            DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
 
-        assertEquals(0, adjustment.damage());
-        assertEquals(List.of("Smoke Bomb active", "Smoke Bomb effect expires"), adjustment.notes());
-        assertTrue(effect.isExpired());
+            assertEquals(0, adjustment.damage());
+            assertEquals(List.of(new SmokeBombActivatedEvent("Owner", "Attacker", 0)), observation.observedEvents());
+            assertTrue(effect.isExpired());
+        }
     }
 
     @Test
@@ -45,11 +53,14 @@ class SmokeBombStatusEffectTest {
         Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
         Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
+        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
 
-        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15);
+        try (StatusEffectObservationScope observation = new StatusEffectObservationScope(eventPublisher)) {
+            DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
 
-        assertEquals(0, adjustment.damage());
-        assertEquals(List.of("Smoke Bomb active"), adjustment.notes());
-        assertFalse(effect.isExpired());
+            assertEquals(0, adjustment.damage());
+            assertEquals(List.of(new SmokeBombActivatedEvent("Owner", "Attacker", 1)), observation.observedEvents());
+            assertFalse(effect.isExpired());
+        }
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/status/SmokeBombStatusEffectTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/SmokeBombStatusEffectTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
 import sc2002.turnbased.support.FakeStatusEffectEventPublisher;
 import sc2002.turnbased.support.TestCombatantBuilder;
 
@@ -38,8 +37,8 @@ class SmokeBombStatusEffectTest {
     @Test
     void adjustIncomingDamage_whenEffectAlreadyExpired_leavesDamageUnchangedAndPublishesNoEvent() {
         // Arrange
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        Combatant owner = TestCombatantBuilder.aCombatant().build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(0);
         FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
@@ -57,8 +56,8 @@ class SmokeBombStatusEffectTest {
     @Test
     void adjustIncomingDamage_whenEnemyAttackConsumesLastCharge_blocksDamageAndExpires() {
         // Arrange
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        Combatant owner = TestCombatantBuilder.aCombatant().build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(1);
         FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
@@ -75,8 +74,8 @@ class SmokeBombStatusEffectTest {
     @Test
     void adjustIncomingDamage_whenChargesRemainAfterFirstBlock_staysActive() {
         // Arrange
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        Combatant owner = TestCombatantBuilder.aCombatant().build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
         FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
@@ -93,8 +92,8 @@ class SmokeBombStatusEffectTest {
     @Test
     void adjustIncomingDamage_whenHitTwice_consumesChargesAcrossCalls() {
         // Arrange
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
+        Combatant owner = TestCombatantBuilder.aCombatant().build();
+        Combatant attacker = TestCombatantBuilder.aCombatant().build();
         SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
         FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
@@ -109,25 +108,6 @@ class SmokeBombStatusEffectTest {
             () -> assertEquals(0, secondAdjustment.damage()),
             () -> assertEquals(25, thirdAdjustment.damage()),
             () -> assertTrue(effect.isExpired())
-        );
-    }
-
-    @Test
-    void adjustIncomingDamage_whenEnemyAttackIsBlocked_publishesActivationEvent() {
-        // Arrange
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        Combatant attacker = TestCombatantBuilder.aCombatant().named("Attacker").build();
-        SmokeBombStatusEffect effect = new SmokeBombStatusEffect(2);
-        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
-        List<SmokeBombActivatedEvent> expectedEvents = List.of(new SmokeBombActivatedEvent("Owner", "Attacker", 1));
-
-        // Act
-        DamageAdjustment adjustment = effect.adjustIncomingDamage(owner, attacker, 15, eventPublisher);
-
-        // Assert
-        assertAll(
-            () -> assertEquals(0, adjustment.damage()),
-            () -> assertEquals(expectedEvents, eventPublisher.publishedEvents())
         );
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/status/StatusEffectRegistryTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/StatusEffectRegistryTest.java
@@ -8,36 +8,52 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.Goblin;
 import sc2002.turnbased.domain.Warrior;
+import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
+import sc2002.turnbased.domain.status.event.StatusEffectExpiredEvent;
+import sc2002.turnbased.support.TestCombatantBuilder;
+import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class StatusEffectRegistryTest {
     @Test
     void resolveTurnWindow_whenStunBlocksNextTurn_marksTurnBlockedAndExpiresEffect() {
-        StatusEffectRegistry registry = new StatusEffectRegistry();
+        StatusEffectRegistry registry = TestDependencies.registry();
+        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
 
-        registry.add(new StunStatusEffect(1));
+        registry.add(owner, new StunStatusEffect(1));
 
-        TurnWindow turnWindow = registry.resolveTurnWindow();
+        try (StatusEffectObservationScope observation = registry.openObservation()) {
+            TurnWindow turnWindow = registry.resolveTurnWindow(owner);
 
-        assertTrue(turnWindow.isBlocked());
-        assertEquals("STUNNED", turnWindow.getBlockerLabel());
-        assertEquals(List.of("Stun expires"), turnWindow.getNotes());
-        assertEquals(List.of(), registry.activeStatusNames(true));
+            assertTrue(turnWindow.isBlocked());
+            assertEquals("STUNNED", turnWindow.getBlockerLabel());
+            assertEquals(List.of(new StatusEffectExpiredEvent("Owner", StatusEffectKind.STUN)), observation.observedEvents());
+            assertEquals(List.of(), registry.activeStatusNames("Owner", true));
+        }
     }
 
     @Test
     void adjustIncomingDamage_whenSmokeBombBlocksEnemyAttack_returnsZeroAndExpiresEffect() {
-        Warrior warrior = new Warrior();
-        Goblin goblin = new Goblin("Goblin");
+        Warrior warrior = TestDependencies.warrior();
+        Goblin goblin = TestDependencies.goblin("Goblin");
 
         warrior.addStatusEffect(new SmokeBombStatusEffect(1));
 
-        DamageAdjustment adjustment = warrior.statusEffects().adjustIncomingDamage(warrior, goblin, 15);
+        try (StatusEffectObservationScope observation = warrior.statusEffects().openObservation()) {
+            DamageAdjustment adjustment = warrior.statusEffects().adjustIncomingDamage(warrior, goblin, 15);
 
-        assertEquals(0, adjustment.damage());
-        assertEquals(List.of("Smoke Bomb active", "Smoke Bomb effect expires"), adjustment.notes());
-        assertEquals(List.of(), warrior.getActiveStatusNames());
+            assertEquals(0, adjustment.damage());
+            assertEquals(
+                List.of(
+                    new SmokeBombActivatedEvent("Warrior", "Goblin", 0),
+                    new StatusEffectExpiredEvent("Warrior", StatusEffectKind.SMOKE_BOMB)
+                ),
+                observation.observedEvents()
+            );
+            assertEquals(List.of(), warrior.getActiveStatusNames());
+        }
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/status/StunStatusEffectTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/StunStatusEffectTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.support.FakeStatusEffectEventPublisher;
 import sc2002.turnbased.support.TestCombatantBuilder;
-import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class StunStatusEffectTest {
@@ -18,7 +18,7 @@ class StunStatusEffectTest {
     void onTurnOpportunity_whenMultipleTurnsRemain_blocksAndExpiresOnLastBlockedTurn() {
         StunStatusEffect effect = new StunStatusEffect(2);
         Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
         TurnEffectResolution firstResolution = effect.onTurnOpportunity(owner, eventPublisher);
 
@@ -37,7 +37,7 @@ class StunStatusEffectTest {
     void onTurnOpportunity_whenAlreadyExpired_allowsTurnWithoutNotes() {
         StunStatusEffect effect = new StunStatusEffect(0);
         Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
-        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
+        FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
         TurnEffectResolution resolution = effect.onTurnOpportunity(owner, eventPublisher);
 

--- a/src/test/java/sc2002/turnbased/domain/status/StunStatusEffectTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/StunStatusEffectTest.java
@@ -5,41 +5,44 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.support.TestCombatantBuilder;
+import sc2002.turnbased.support.TestDependencies;
 
 @Tag("unit")
 class StunStatusEffectTest {
     @Test
     void onTurnOpportunity_whenMultipleTurnsRemain_blocksAndExpiresOnLastBlockedTurn() {
         StunStatusEffect effect = new StunStatusEffect(2);
+        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
 
-        TurnEffectResolution firstResolution = effect.onTurnOpportunity();
+        TurnEffectResolution firstResolution = effect.onTurnOpportunity(owner, eventPublisher);
 
         assertEquals("STUNNED", effect.name());
         assertTrue(firstResolution.blocksAction());
         assertEquals("STUNNED", firstResolution.blockerLabel());
-        assertEquals(List.of(), firstResolution.notes());
         assertFalse(effect.isExpired());
 
-        TurnEffectResolution secondResolution = effect.onTurnOpportunity();
+        TurnEffectResolution secondResolution = effect.onTurnOpportunity(owner, eventPublisher);
 
         assertTrue(secondResolution.blocksAction());
-        assertEquals(List.of("Stun expires"), secondResolution.notes());
         assertTrue(effect.isExpired());
     }
 
     @Test
     void onTurnOpportunity_whenAlreadyExpired_allowsTurnWithoutNotes() {
         StunStatusEffect effect = new StunStatusEffect(0);
+        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        StatusEffectEventPublisher eventPublisher = TestDependencies.statusEffectEventPublisher();
 
-        TurnEffectResolution resolution = effect.onTurnOpportunity();
+        TurnEffectResolution resolution = effect.onTurnOpportunity(owner, eventPublisher);
 
         assertFalse(resolution.blocksAction());
         assertNull(resolution.blockerLabel());
-        assertEquals(List.of(), resolution.notes());
         assertTrue(effect.isExpired());
     }
 }

--- a/src/test/java/sc2002/turnbased/domain/status/StunStatusEffectTest.java
+++ b/src/test/java/sc2002/turnbased/domain/status/StunStatusEffectTest.java
@@ -17,7 +17,7 @@ class StunStatusEffectTest {
     @Test
     void onTurnOpportunity_whenMultipleTurnsRemain_blocksAndExpiresOnLastBlockedTurn() {
         StunStatusEffect effect = new StunStatusEffect(2);
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        Combatant owner = TestCombatantBuilder.aCombatant().build();
         FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
         TurnEffectResolution firstResolution = effect.onTurnOpportunity(owner, eventPublisher);
@@ -36,7 +36,7 @@ class StunStatusEffectTest {
     @Test
     void onTurnOpportunity_whenAlreadyExpired_allowsTurnWithoutNotes() {
         StunStatusEffect effect = new StunStatusEffect(0);
-        Combatant owner = TestCombatantBuilder.aCombatant().named("Owner").build();
+        Combatant owner = TestCombatantBuilder.aCombatant().build();
         FakeStatusEffectEventPublisher eventPublisher = new FakeStatusEffectEventPublisher();
 
         TurnEffectResolution resolution = effect.onTurnOpportunity(owner, eventPublisher);

--- a/src/test/java/sc2002/turnbased/e2e/CustomBattleFlowE2ETest.java
+++ b/src/test/java/sc2002/turnbased/e2e/CustomBattleFlowE2ETest.java
@@ -25,6 +25,10 @@ import sc2002.turnbased.actions.UseSpecialSkillAction;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.domain.status.StatusEffectKind;
+import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+import sc2002.turnbased.domain.status.event.StatusEffectExpiredEvent;
 import sc2002.turnbased.engine.BattleEngine;
 import sc2002.turnbased.engine.BattleSetup;
 import sc2002.turnbased.engine.BattleSetupFactory;
@@ -42,13 +46,14 @@ import sc2002.turnbased.report.RoundSummaryEvent;
 import sc2002.turnbased.report.SkippedTurnEvent;
 import sc2002.turnbased.support.BattleTestSupport;
 import sc2002.turnbased.support.BattleTestSupport.RoundCapture;
+import sc2002.turnbased.support.TestDependencies;
 
 @Tag("e2e")
 class CustomBattleFlowE2ETest {
     @Test
     @DisplayName("Medium warrior battle flow matches the expected end-to-end transcript")
     void mediumWarriorBattleFlowMatchesExpectedTranscript() {
-        BattleSetup battleSetup = new BattleSetupFactory().create(
+        BattleSetup battleSetup = TestDependencies.battleSetupFactory().create(
             new GameConfiguration(
                 PlayerType.WARRIOR,
                 DifficultyLevel.MEDIUM,
@@ -126,16 +131,23 @@ class CustomBattleFlowE2ETest {
             enemy("Wolf B", 0, false, Set.of())
         );
 
-        assertAction(rounds.get(2), "Goblin", "Warrior", 0, 20, Set.of("Smoke Bomb active"));
-        assertAction(rounds.get(3), "Goblin", "Warrior", 0, 20, Set.of("Smoke Bomb active", "Smoke Bomb effect expires"));
-        assertAction(rounds.get(4), "Goblin", "Warrior", 5, 30, Set.of());
-        assertAction(rounds.get(10), "Wolf A", "Warrior", 15, 30, Set.of());
-        assertAction(rounds.get(10), "Wolf B", "Warrior", 15, 30, Set.of());
+        assertAction(rounds.get(2), "Goblin", "Warrior", 0, 20,
+            List.of(new SmokeBombActivatedEvent("Warrior", "Goblin", 1)));
+        assertAction(rounds.get(3), "Goblin", "Warrior", 0, 20,
+            List.of(
+                new SmokeBombActivatedEvent("Warrior", "Goblin", 0),
+                new StatusEffectExpiredEvent("Warrior", StatusEffectKind.SMOKE_BOMB)
+            ));
+        assertAction(rounds.get(4), "Goblin", "Warrior", 5, 30, List.of());
+        assertAction(rounds.get(10), "Wolf A", "Warrior", 15, 30, List.of());
+        assertAction(rounds.get(10), "Wolf B", "Warrior", 15, 30, List.of());
 
-        assertSkipped(rounds.get(2), "Wolf", "STUNNED", Set.of());
-        assertSkipped(rounds.get(3), "Wolf", "STUNNED", Set.of("Stun expires"));
-        assertSkipped(rounds.get(5), "Goblin", "STUNNED", Set.of());
-        assertSkipped(rounds.get(6), "Goblin", "STUNNED", Set.of("Stun expires"));
+        assertSkipped(rounds.get(2), "Wolf", "STUNNED", List.of());
+        assertSkipped(rounds.get(3), "Wolf", "STUNNED",
+            List.of(new StatusEffectExpiredEvent("Wolf", StatusEffectKind.STUN)));
+        assertSkipped(rounds.get(5), "Goblin", "STUNNED", List.of());
+        assertSkipped(rounds.get(6), "Goblin", "STUNNED",
+            List.of(new StatusEffectExpiredEvent("Goblin", StatusEffectKind.STUN)));
 
         assertNarrationContains(rounds.get(8), "Backup Spawn triggered: Wolf A, Wolf B");
         assertVictoryNarration(events);
@@ -185,7 +197,7 @@ class CustomBattleFlowE2ETest {
         String target,
         int expectedDamage,
         int expectedDefense,
-        Set<String> expectedNotes
+        List<StatusEffectEvent> expectedStatusEffectEvents
     ) {
         assertNotNull(roundCapture, "Missing expected round capture");
 
@@ -199,7 +211,11 @@ class CustomBattleFlowE2ETest {
         assertAll(
             () -> assertEquals(expectedDamage, actionEvent.getDamage(), "Unexpected damage for " + actor + " -> " + target),
             () -> assertEquals(expectedDefense, actionEvent.getTargetDefense(), "Unexpected target defense for " + actor + " -> " + target),
-            () -> assertTrue(actionEvent.getNotes().containsAll(expectedNotes), "Unexpected notes for " + actor + " -> " + target)
+            () -> assertEquals(
+                expectedStatusEffectEvents,
+                actionEvent.getStatusEffectEvents(),
+                "Unexpected status effect events for " + actor + " -> " + target
+            )
         );
     }
 
@@ -207,7 +223,7 @@ class CustomBattleFlowE2ETest {
         RoundCapture roundCapture,
         String combatantName,
         String expectedReason,
-        Set<String> expectedNotes
+        List<StatusEffectEvent> expectedStatusEffectEvents
     ) {
         assertNotNull(roundCapture, "Missing expected round capture");
 
@@ -220,7 +236,11 @@ class CustomBattleFlowE2ETest {
 
         assertAll(
             () -> assertEquals(expectedReason, skippedTurnEvent.getReason(), "Unexpected skip reason for " + combatantName),
-            () -> assertTrue(skippedTurnEvent.getNotes().containsAll(expectedNotes), "Unexpected skip notes for " + combatantName)
+            () -> assertEquals(
+                expectedStatusEffectEvents,
+                skippedTurnEvent.getStatusEffectEvents(),
+                "Unexpected status effect events for " + combatantName
+            )
         );
     }
 

--- a/src/test/java/sc2002/turnbased/integration/BattleEngineAppendixAScenariosIntegrationTest.java
+++ b/src/test/java/sc2002/turnbased/integration/BattleEngineAppendixAScenariosIntegrationTest.java
@@ -18,10 +18,10 @@ import sc2002.turnbased.support.BattleTestSupport;
 import sc2002.turnbased.support.BattleTestSupport.ScenarioRun;
 
 @Tag("integration")
-class AppendixAScenariosIntegrationTest {
+class BattleEngineAppendixAScenariosIntegrationTest {
     @Test
-    @DisplayName("Appendix A easy warrior scenario matches expected transcript and round state")
-    void easyWarriorScenarioMatchesExpectedState() {
+    @DisplayName("BattleEngine and Appendix A easy warrior scenario produce expected transcript and round state")
+    void battleEngine_andAppendixAEasyWarriorScenario_produceExpectedTranscriptAndRoundState() {
         ScenarioRun run = BattleTestSupport.runScenario(AppendixAScenarios.easyWarrior());
 
         assertEquals(11, run.summaries().size());
@@ -89,8 +89,8 @@ class AppendixAScenariosIntegrationTest {
     }
 
     @Test
-    @DisplayName("Appendix A medium warrior scenario matches expected transcript and round state")
-    void mediumWarriorScenarioMatchesExpectedState() {
+    @DisplayName("BattleEngine and Appendix A medium warrior scenario produce expected transcript and round state")
+    void battleEngine_andAppendixAMediumWarriorScenario_produceExpectedTranscriptAndRoundState() {
         ScenarioRun run = BattleTestSupport.runScenario(AppendixAScenarios.mediumWarrior());
 
         assertEquals(9, run.summaries().size());
@@ -149,8 +149,8 @@ class AppendixAScenariosIntegrationTest {
     }
 
     @Test
-    @DisplayName("Appendix A medium wizard scenario matches expected transcript and round state")
-    void mediumWizardScenarioMatchesExpectedState() {
+    @DisplayName("BattleEngine and Appendix A medium wizard scenario produce expected transcript and round state")
+    void battleEngine_andAppendixAMediumWizardScenario_produceExpectedTranscriptAndRoundState() {
         ScenarioRun run = BattleTestSupport.runScenario(AppendixAScenarios.mediumWizard());
 
         assertEquals(3, run.summaries().size());

--- a/src/test/java/sc2002/turnbased/integration/BattleEngineEasyLevelRoundsIntegrationTest.java
+++ b/src/test/java/sc2002/turnbased/integration/BattleEngineEasyLevelRoundsIntegrationTest.java
@@ -25,10 +25,10 @@ import sc2002.turnbased.report.RoundSummaryEvent;
 import sc2002.turnbased.support.BattleTestSupport;
 
 @Tag("integration")
-class EasyLevelRoundsIntegrationTest {
+class BattleEngineEasyLevelRoundsIntegrationTest {
     @Test
-    @DisplayName("Easy warrior opening rounds stay deterministic")
-    void easyWarriorOpeningRoundsStayDeterministic() {
+    @DisplayName("BattleEngine and easy warrior opening script produce deterministic round summaries")
+    void battleEngine_andEasyWarriorOpeningScript_produceDeterministicRoundSummaries() {
         BattleSetup battleSetup = EasyLevelSetup.createWarriorPotionSmokeBombSetup();
         BattleEngine battleEngine = new BattleEngine(battleSetup, new SpeedTurnOrderStrategy());
 

--- a/src/test/java/sc2002/turnbased/integration/StatusEffectObservationScopeBattleFlowIntegrationTest.java
+++ b/src/test/java/sc2002/turnbased/integration/StatusEffectObservationScopeBattleFlowIntegrationTest.java
@@ -31,6 +31,43 @@ import sc2002.turnbased.support.TestDependencies;
 @Tag("integration")
 class StatusEffectObservationScopeBattleFlowIntegrationTest {
     @Test
+    @DisplayName("StatusEffectObservationScope and BattleEngine publish Smoke Bomb activation events")
+    void statusEffectObservationScope_andBattleEngine_publishSmokeBombActivationEvents() {
+        // Arrange
+        BattleSetup battleSetup = TestDependencies.battleSetupFactory().createCustom(
+            new CustomGameConfiguration(
+                PlayerType.WARRIOR,
+                List.of(ItemType.SMOKE_BOMB, ItemType.POTION),
+                List.of(WaveSpec.of(
+                    EnemyCount.of(EnemyType.GOBLIN, 1),
+                    EnemyCount.of(EnemyType.WOLF, 0)
+                ))
+            )
+        );
+        BattleEngine battleEngine = new BattleEngine(battleSetup, new SpeedTurnOrderStrategy());
+        ScriptedDecisionProvider decisions = new ScriptedDecisionProvider()
+            .addDecision(1, PlayerDecision.untargeted(new UseSmokeBombAction()));
+
+        try (StatusEffectObservationScope observation = battleSetup.getPlayer().statusEffects().openObservation()) {
+            // Act
+            battleEngine.runRounds(1, decisions);
+
+            // Assert
+            assertAll(
+                () -> assertEquals(
+                    List.of(
+                        new SmokeBombAppliedEvent("Warrior", 2),
+                        new SmokeBombActivatedEvent("Warrior", "Goblin A", 1)
+                    ),
+                    observation.observedEvents()
+                ),
+                () -> assertEquals(260, battleSetup.getPlayer().getCurrentHp()),
+                () -> assertEquals(List.of("SMOKE BOMB"), battleSetup.getPlayer().getActiveStatusNames())
+            );
+        }
+    }
+
+    @Test
     @DisplayName("StatusEffectObservationScope and BattleEngine publish Smoke Bomb lifecycle events")
     void statusEffectObservationScope_andBattleEngine_publishSmokeBombLifecycleEvents() {
         // Arrange

--- a/src/test/java/sc2002/turnbased/integration/StatusEffectObservationScopeBattleFlowIntegrationTest.java
+++ b/src/test/java/sc2002/turnbased/integration/StatusEffectObservationScopeBattleFlowIntegrationTest.java
@@ -1,0 +1,71 @@
+package sc2002.turnbased.integration;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.UseSmokeBombAction;
+import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.status.StatusEffectKind;
+import sc2002.turnbased.domain.status.StatusEffectObservationScope;
+import sc2002.turnbased.domain.status.event.SmokeBombActivatedEvent;
+import sc2002.turnbased.domain.status.event.SmokeBombAppliedEvent;
+import sc2002.turnbased.domain.status.event.StatusEffectExpiredEvent;
+import sc2002.turnbased.engine.BattleEngine;
+import sc2002.turnbased.engine.BattleSetup;
+import sc2002.turnbased.engine.CustomGameConfiguration;
+import sc2002.turnbased.engine.EnemyCount;
+import sc2002.turnbased.engine.EnemyType;
+import sc2002.turnbased.engine.PlayerDecision;
+import sc2002.turnbased.engine.PlayerType;
+import sc2002.turnbased.engine.ScriptedDecisionProvider;
+import sc2002.turnbased.engine.SpeedTurnOrderStrategy;
+import sc2002.turnbased.engine.WaveSpec;
+import sc2002.turnbased.support.TestDependencies;
+
+@Tag("integration")
+class StatusEffectObservationScopeBattleFlowIntegrationTest {
+    @Test
+    @DisplayName("StatusEffectObservationScope and BattleEngine publish Smoke Bomb lifecycle events")
+    void statusEffectObservationScope_andBattleEngine_publishSmokeBombLifecycleEvents() {
+        // Arrange
+        BattleSetup battleSetup = TestDependencies.battleSetupFactory().createCustom(
+            new CustomGameConfiguration(
+                PlayerType.WARRIOR,
+                List.of(ItemType.SMOKE_BOMB, ItemType.POTION),
+                List.of(WaveSpec.of(
+                    EnemyCount.of(EnemyType.GOBLIN, 2),
+                    EnemyCount.of(EnemyType.WOLF, 0)
+                ))
+            )
+        );
+        BattleEngine battleEngine = new BattleEngine(battleSetup, new SpeedTurnOrderStrategy());
+        ScriptedDecisionProvider decisions = new ScriptedDecisionProvider()
+            .addDecision(1, PlayerDecision.untargeted(new UseSmokeBombAction()));
+
+        try (StatusEffectObservationScope observation = battleSetup.getPlayer().statusEffects().openObservation()) {
+            // Act
+            battleEngine.runRounds(1, decisions);
+
+            // Assert
+            assertAll(
+                () -> assertEquals(
+                    List.of(
+                        new SmokeBombAppliedEvent("Warrior", 2),
+                        new SmokeBombActivatedEvent("Warrior", "Goblin A", 1),
+                        new SmokeBombActivatedEvent("Warrior", "Goblin B", 0),
+                        new StatusEffectExpiredEvent("Warrior", StatusEffectKind.SMOKE_BOMB)
+                    ),
+                    observation.observedEvents()
+                ),
+                () -> assertEquals(260, battleSetup.getPlayer().getCurrentHp()),
+                () -> assertEquals(List.of(), battleSetup.getPlayer().getActiveStatusNames())
+            );
+        }
+    }
+}

--- a/src/test/java/sc2002/turnbased/support/FakeStatusEffectEventPublisher.java
+++ b/src/test/java/sc2002/turnbased/support/FakeStatusEffectEventPublisher.java
@@ -1,0 +1,20 @@
+package sc2002.turnbased.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sc2002.turnbased.domain.status.StatusEffectEventPublisher;
+import sc2002.turnbased.domain.status.event.StatusEffectEvent;
+
+public class FakeStatusEffectEventPublisher extends StatusEffectEventPublisher {
+    private final List<StatusEffectEvent> publishedEvents = new ArrayList<>();
+
+    @Override
+    public void publish(StatusEffectEvent event) {
+        publishedEvents.add(event);
+    }
+
+    public List<StatusEffectEvent> publishedEvents() {
+        return List.copyOf(publishedEvents);
+    }
+}

--- a/src/test/java/sc2002/turnbased/support/TestCombatantBuilder.java
+++ b/src/test/java/sc2002/turnbased/support/TestCombatantBuilder.java
@@ -3,7 +3,8 @@ package sc2002.turnbased.support;
 import sc2002.turnbased.domain.CombatStats;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.HitPoints;
-import sc2002.turnbased.domain.Stat;
+import sc2002.turnbased.domain.status.StatusEffectEventPublisher;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
 
 public final class TestCombatantBuilder {
     private String name = "Test Combatant";
@@ -58,13 +59,14 @@ public final class TestCombatantBuilder {
                 .attack(attack)
                 .defense(defense)
                 .speed(speed)
-                .build()
+                .build(),
+            new StatusEffectRegistry(new StatusEffectEventPublisher())
         );
     }
 
     private static final class TestCombatant extends Combatant {
-        private TestCombatant(String name, HitPoints hitPoints, CombatStats baseStats) {
-            super(name, hitPoints, baseStats);
+        private TestCombatant(String name, HitPoints hitPoints, CombatStats baseStats, StatusEffectRegistry statusEffectRegistry) {
+            super(name, hitPoints, baseStats, statusEffectRegistry);
         }
     }
 }

--- a/src/test/java/sc2002/turnbased/support/TestDependencies.java
+++ b/src/test/java/sc2002/turnbased/support/TestDependencies.java
@@ -52,8 +52,4 @@ public final class TestDependencies {
     public static StatusEffectRegistry registry() {
         return STATUS_EFFECT_REGISTRY_FACTORY.create();
     }
-
-    public static StatusEffectEventPublisher statusEffectEventPublisher() {
-        return new StatusEffectEventPublisher();
-    }
 }

--- a/src/test/java/sc2002/turnbased/support/TestDependencies.java
+++ b/src/test/java/sc2002/turnbased/support/TestDependencies.java
@@ -1,0 +1,59 @@
+package sc2002.turnbased.support;
+
+import sc2002.turnbased.actions.ArcaneBlastAction;
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ShieldBashAction;
+import sc2002.turnbased.domain.CombatantFactory;
+import sc2002.turnbased.domain.DefaultCombatantFactory;
+import sc2002.turnbased.domain.Goblin;
+import sc2002.turnbased.domain.Warrior;
+import sc2002.turnbased.domain.Wizard;
+import sc2002.turnbased.domain.status.StatusEffectEventPublisher;
+import sc2002.turnbased.domain.status.StatusEffectRegistry;
+import sc2002.turnbased.domain.status.StatusEffectRegistryFactory;
+import sc2002.turnbased.engine.BattleSetupFactory;
+import sc2002.turnbased.engine.EnemyType;
+import sc2002.turnbased.engine.PlayerType;
+
+public final class TestDependencies {
+    private static final StatusEffectRegistryFactory STATUS_EFFECT_REGISTRY_FACTORY = () ->
+        new StatusEffectRegistry(new StatusEffectEventPublisher());
+
+    private static final CombatantFactory COMBATANT_FACTORY = new DefaultCombatantFactory(
+        STATUS_EFFECT_REGISTRY_FACTORY,
+        new BasicAttackAction(),
+        new ShieldBashAction(),
+        new ArcaneBlastAction()
+    );
+
+    private TestDependencies() {
+    }
+
+    public static CombatantFactory combatantFactory() {
+        return COMBATANT_FACTORY;
+    }
+
+    public static BattleSetupFactory battleSetupFactory() {
+        return new BattleSetupFactory(COMBATANT_FACTORY);
+    }
+
+    public static Warrior warrior() {
+        return (Warrior) COMBATANT_FACTORY.createPlayer(PlayerType.WARRIOR);
+    }
+
+    public static Wizard wizard() {
+        return (Wizard) COMBATANT_FACTORY.createPlayer(PlayerType.WIZARD);
+    }
+
+    public static Goblin goblin(String name) {
+        return (Goblin) COMBATANT_FACTORY.createEnemy(EnemyType.GOBLIN, name);
+    }
+
+    public static StatusEffectRegistry registry() {
+        return STATUS_EFFECT_REGISTRY_FACTORY.create();
+    }
+
+    public static StatusEffectEventPublisher statusEffectEventPublisher() {
+        return new StatusEffectEventPublisher();
+    }
+}


### PR DESCRIPTION
Closes #15 
## Summary

This refactors the status effect system so the domain no longer builds UI-facing messages.

Instead of pushing presentation strings through battle actions and effects, status effects now publish typed domain events through an observer-style event stream. Reporting and formatting are handled outside the domain.

## What Changed

- introduced typed status effect events for apply, activation, and expiry flows
- refactored `StatusEffectRegistry` into an event publisher/observer model
- removed UI-facing note construction from status effects such as smoke bomb
- added `StatusEffectReportEvent` so battle reporting can carry domain events without embedding presentation text
- moved combatant/status-effect manager construction behind injected factories instead of instantiating dependencies inside entities
- updated battle setup and UI wiring to consume the new event-driven flow
- simplified status effect unit tests to focus on domain state transitions
- added integration coverage for observable smoke bomb lifecycle and activation events
- renamed integration tests to describe scenario + collaboration more clearly

## Why

This change fixes the architectural boundary problem where domain logic was constructing UI messages.

It also improves the design against SOLID concerns:
- SRP: status effects now handle game behavior, while reporting/formatting handle presentation
- OCP: new status effect events can be added without reintroducing UI logic into the domain
- DI consistency: external services and state managers are now injected instead of created inside domain classes

## Testing

- `mvn -q test`
