### PR TITLE
refactor: move inventory into combatants

### DIFF
--- a/src/main/java/sc2002/turnbased/actions/ActionExecutionContext.java
+++ b/src/main/java/sc2002/turnbased/actions/ActionExecutionContext.java
@@ -3,12 +3,9 @@ package sc2002.turnbased.actions;
 import java.util.List;
 
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.Inventory;
 
 public interface ActionExecutionContext {
     List<Combatant> getLivingEnemies();
 
     List<Combatant> getLivingEnemiesInTurnOrder();
-
-    Inventory getInventory();
 }

--- a/src/main/java/sc2002/turnbased/actions/UsePotionAction.java
+++ b/src/main/java/sc2002/turnbased/actions/UsePotionAction.java
@@ -20,7 +20,7 @@ public class UsePotionAction implements BattleAction {
 
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
-        context.getInventory().use(ItemType.POTION);
+        actor.getInventory().use(ItemType.POTION);
         int hpBefore = actor.getCurrentHp();
         actor.heal(100);
         return List.of(new NarrationEvent(

--- a/src/main/java/sc2002/turnbased/actions/UsePowerStoneSkillAction.java
+++ b/src/main/java/sc2002/turnbased/actions/UsePowerStoneSkillAction.java
@@ -30,10 +30,10 @@ public class UsePowerStoneSkillAction implements BattleAction {
 
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
-        actor.getInventory().use(ItemType.POWER_STONE);
         if (!(actor instanceof PlayerCharacter player)) {
             throw new IllegalStateException("Power Stone is only supported for player characters");
         }
+        actor.getInventory().use(ItemType.POWER_STONE);
 
         List<BattleEvent> events = new ArrayList<>();
         String intro = actor.getName() + " -> Item -> Power Stone used -> " + player.getSpecialSkillName() + " triggered";

--- a/src/main/java/sc2002/turnbased/actions/UsePowerStoneSkillAction.java
+++ b/src/main/java/sc2002/turnbased/actions/UsePowerStoneSkillAction.java
@@ -30,7 +30,7 @@ public class UsePowerStoneSkillAction implements BattleAction {
 
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
-        context.getInventory().use(ItemType.POWER_STONE);
+        actor.getInventory().use(ItemType.POWER_STONE);
         if (!(actor instanceof PlayerCharacter player)) {
             throw new IllegalStateException("Power Stone is only supported for player characters");
         }

--- a/src/main/java/sc2002/turnbased/actions/UseSmokeBombAction.java
+++ b/src/main/java/sc2002/turnbased/actions/UseSmokeBombAction.java
@@ -22,7 +22,7 @@ public class UseSmokeBombAction implements BattleAction {
 
     @Override
     public List<BattleEvent> execute(ActionExecutionContext context, Combatant actor, Combatant target) {
-        context.getInventory().use(ItemType.SMOKE_BOMB);
+        actor.getInventory().use(ItemType.SMOKE_BOMB);
         return List.of(
             new NarrationEvent(actor.getName() + " -> Item -> Smoke Bomb used"),
             StatusEffectReportEvent.fromStatusEffectOutcomes(actor.addStatusEffect(new SmokeBombStatusEffect(2)))

--- a/src/main/java/sc2002/turnbased/domain/Combatant.java
+++ b/src/main/java/sc2002/turnbased/domain/Combatant.java
@@ -15,12 +15,14 @@ public abstract class Combatant {
     private final CombatantId combatantId;
     private final String name;
     private final CombatStats baseStats;
+    private final Inventory inventory;
     private HitPoints hitPoints;
     private final StatusEffectRegistry statusEffectRegistry;
 
     protected Combatant(String name, HitPoints baseHitPoints, CombatStats baseStats, StatusEffectRegistry statusEffectRegistry) {
         this.name = Objects.requireNonNull(name, "name");
         this.combatantId = CombatantId.generate();
+        this.inventory = new Inventory();
         this.hitPoints = Objects.requireNonNull(baseHitPoints, "baseHitPoints");
         this.baseStats = Objects.requireNonNull(baseStats, "baseStats");
         this.statusEffectRegistry = Objects.requireNonNull(statusEffectRegistry, "statusEffectRegistry");
@@ -44,6 +46,10 @@ public abstract class Combatant {
 
     public HitPoints getHitPoints() {
         return hitPoints;
+    }
+
+    public Inventory getInventory() {
+        return inventory;
     }
 
     public int getAttack() {

--- a/src/main/java/sc2002/turnbased/engine/BattleEngine.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleEngine.java
@@ -6,7 +6,6 @@ import java.util.List;
 import sc2002.turnbased.actions.ActionExecutionContext;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.EnemyCombatant;
-import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.PlayerCharacter;
 import sc2002.turnbased.domain.status.CombatantStatusOutcome;
@@ -23,7 +22,6 @@ public class BattleEngine implements ActionExecutionContext {
     private final List<Combatant> initialEnemies;
     private final List<Combatant> reserveEnemies;
     private final List<Combatant> spawnedEnemies;
-    private final Inventory inventory;
     private final TurnOrderStrategy turnOrderStrategy;
     private final List<BattleEvent> events = new ArrayList<>();
 
@@ -32,7 +30,6 @@ public class BattleEngine implements ActionExecutionContext {
         this.initialEnemies = new ArrayList<>(battleSetup.getInitialEnemies());
         this.reserveEnemies = new ArrayList<>(battleSetup.getBackupEnemies());
         this.spawnedEnemies = new ArrayList<>(battleSetup.getInitialEnemies());
-        this.inventory = battleSetup.getInventory();
         this.turnOrderStrategy = turnOrderStrategy;
     }
 
@@ -173,11 +170,6 @@ public class BattleEngine implements ActionExecutionContext {
         return turnOrderStrategy.determineOrder(livingEnemies());
     }
 
-    @Override
-    public Inventory getInventory() {
-        return inventory;
-    }
-
     private List<Combatant> livingEnemies() {
         List<Combatant> livingEnemies = new ArrayList<>();
         for (Combatant enemy : spawnedEnemies) {
@@ -228,7 +220,7 @@ public class BattleEngine implements ActionExecutionContext {
             roundNumber,
             toSummary(player),
             enemySummaries,
-            inventory.snapshot(),
+            player.getInventory().snapshot(),
             player.getSpecialSkillCooldown()
         );
     }
@@ -267,8 +259,13 @@ public class BattleEngine implements ActionExecutionContext {
         emit(new NarrationEvent("Victory:"), battleEventListener);
         emit(new NarrationEvent("Remaining HP: " + player.getCurrentHp() + " / " + player.getMaxHp()), battleEventListener);
         emit(new NarrationEvent("Total Rounds: " + roundsPlayed), battleEventListener);
-        for (ItemType itemType : inventory.snapshot().keySet()) {
-            emit(new NarrationEvent("Remaining " + itemType.getDisplayName() + ": " + inventory.countOf(itemType)), battleEventListener);
+        for (ItemType itemType : player.getInventory().snapshot().keySet()) {
+            emit(
+                new NarrationEvent(
+                    "Remaining " + itemType.getDisplayName() + ": " + player.getInventory().countOf(itemType)
+                ),
+                battleEventListener
+            );
         }
         if (player.getAttack() != player.getBaseAttack()) {
             emit(new NarrationEvent("Final " + player.getName() + " ATK: " + player.getAttack()), battleEventListener);

--- a/src/main/java/sc2002/turnbased/engine/BattleSetup.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleSetup.java
@@ -6,20 +6,17 @@ import java.util.List;
 import java.util.Objects;
 
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.PlayerCharacter;
 
 public class BattleSetup {
     private final PlayerCharacter player;
     private final List<Combatant> initialEnemies;
     private final List<Combatant> backupEnemies;
-    private final Inventory inventory;
 
-    public BattleSetup(PlayerCharacter player, List<Combatant> initialEnemies, List<Combatant> backupEnemies, Inventory inventory) {
+    public BattleSetup(PlayerCharacter player, List<Combatant> initialEnemies, List<Combatant> backupEnemies) {
         this.player = Objects.requireNonNull(player, "player");
         this.initialEnemies = new ArrayList<>(Objects.requireNonNull(initialEnemies, "initialEnemies"));
         this.backupEnemies = new ArrayList<>(Objects.requireNonNull(backupEnemies, "backupEnemies"));
-        this.inventory = Objects.requireNonNull(inventory, "inventory");
     }
 
     public PlayerCharacter getPlayer() {
@@ -32,9 +29,5 @@ public class BattleSetup {
 
     public List<Combatant> getBackupEnemies() {
         return Collections.unmodifiableList(backupEnemies);
-    }
-
-    public Inventory getInventory() {
-        return inventory;
     }
 }

--- a/src/main/java/sc2002/turnbased/engine/BattleSetupFactory.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleSetupFactory.java
@@ -21,7 +21,7 @@ public class BattleSetupFactory {
 
     public BattleSetup create(GameConfiguration configuration) {
         PlayerCharacter player = configuration.playerType().createPlayer(combatantFactory);
-        Inventory inventory = createInventory(configuration.selectedItems());
+        populateInventory(player, configuration.selectedItems());
 
         return switch (configuration.difficultyLevel()) {
             case EASY -> new BattleSetup(
@@ -31,8 +31,7 @@ public class BattleSetupFactory {
                     EnemyType.GOBLIN.create("Goblin B", combatantFactory),
                     EnemyType.GOBLIN.create("Goblin C", combatantFactory)
                 ),
-                List.of(),
-                inventory
+                List.of()
             );
             case MEDIUM -> new BattleSetup(
                 player,
@@ -43,8 +42,7 @@ public class BattleSetupFactory {
                 List.of(
                     EnemyType.WOLF.create("Wolf A", combatantFactory),
                     EnemyType.WOLF.create("Wolf B", combatantFactory)
-                ),
-                inventory
+                )
             );
             case HARD -> new BattleSetup(
                 player,
@@ -56,19 +54,18 @@ public class BattleSetupFactory {
                     EnemyType.GOBLIN.create("Goblin C", combatantFactory),
                     EnemyType.WOLF.create("Wolf A", combatantFactory),
                     EnemyType.WOLF.create("Wolf B", combatantFactory)
-                ),
-                inventory
+                )
             );
         };
     }
 
     public BattleSetup createCustom(CustomGameConfiguration config) {
         PlayerCharacter player = config.playerType().createPlayer(combatantFactory);
-        Inventory inventory = createInventory(config.selectedItems());
-        return buildSetup(player, inventory, config.waves());
+        populateInventory(player, config.selectedItems());
+        return buildSetup(player, config.waves());
     }
 
-    private BattleSetup buildSetup(PlayerCharacter player, Inventory inventory, List<WaveSpec> waves) {
+    private BattleSetup buildSetup(PlayerCharacter player, List<WaveSpec> waves) {
         Objects.requireNonNull(waves, "waves");
         if (waves.isEmpty() || waves.size() > 2) {
             throw new IllegalArgumentException("Battle setup requires 1 or 2 waves, got: " + waves.size());
@@ -79,7 +76,7 @@ public class BattleSetupFactory {
         List<Combatant> wave2 = waves.size() > 1
             ? buildWave(waves.get(1), nextLabelByFactory)
             : List.of();
-        return new BattleSetup(player, wave1, wave2, inventory);
+        return new BattleSetup(player, wave1, wave2);
     }
 
     private List<Combatant> buildWave(WaveSpec spec, Map<EnemyFactory, Integer> nextLabelByFactory) {
@@ -105,11 +102,10 @@ public class BattleSetupFactory {
         return enemyFactory.getDisplayName() + " " + (enemyIndex + 1);
     }
 
-    private Inventory createInventory(List<ItemType> selectedItems) {
-        Inventory inventory = new Inventory();
+    private void populateInventory(PlayerCharacter player, List<ItemType> selectedItems) {
+        Inventory inventory = player.getInventory();
         for (ItemType itemType : selectedItems) {
             inventory.add(itemType, 1);
         }
-        return inventory;
     }
 }

--- a/src/main/java/sc2002/turnbased/ui/CliPlayerDecisionProvider.java
+++ b/src/main/java/sc2002/turnbased/ui/CliPlayerDecisionProvider.java
@@ -20,17 +20,15 @@ import sc2002.turnbased.engine.PlayerDecisionProvider;
 
 public class CliPlayerDecisionProvider implements PlayerDecisionProvider {
     private final ConsoleBattleUi ui;
-    private final Inventory inventory;
 
-    public CliPlayerDecisionProvider(ConsoleBattleUi ui, Inventory inventory) {
+    public CliPlayerDecisionProvider(ConsoleBattleUi ui) {
         this.ui = ui;
-        this.inventory = inventory;
     }
 
     @Override
     public PlayerDecision decide(int roundNumber, PlayerCharacter player, List<Combatant> livingEnemies) {
         while (true) {
-            ui.showPlayerTurn(roundNumber, player, livingEnemies, inventory);
+            ui.showPlayerTurn(roundNumber, player, livingEnemies);
 
             List<String> options = new ArrayList<>();
             options.add("BasicAttack");
@@ -67,6 +65,7 @@ public class CliPlayerDecisionProvider implements PlayerDecisionProvider {
     }
 
     private PlayerDecision promptForItemDecision(PlayerCharacter player, List<Combatant> livingEnemies) {
+        Inventory inventory = player.getInventory();
         List<ItemType> availableItems = new ArrayList<>();
         for (ItemType itemType : ItemType.values()) {
             if (inventory.countOf(itemType) > 0) {

--- a/src/main/java/sc2002/turnbased/ui/ConsoleBattleUi.java
+++ b/src/main/java/sc2002/turnbased/ui/ConsoleBattleUi.java
@@ -5,9 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
-import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.Inventory;
+import sc2002.turnbased.domain.CombatantFactory;
 import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.PlayerCharacter;
 import sc2002.turnbased.engine.DifficultyLevel;
@@ -151,7 +150,7 @@ public class ConsoleBattleUi {
         out.println();
     }
 
-    public void showPlayerTurn(int roundNumber, PlayerCharacter player, List<Combatant> livingEnemies, Inventory inventory) {
+    public void showPlayerTurn(int roundNumber, PlayerCharacter player, List<Combatant> livingEnemies) {
         out.println();
         out.println("Round " + roundNumber + " - " + player.getName() + "'s Turn");
         out.println("Player: HP " + player.getCurrentHp() + "/" + player.getMaxHp()
@@ -159,7 +158,7 @@ public class ConsoleBattleUi {
             + " | DEF " + player.getDefense()
             + " | SPD " + player.getSpeed()
             + " | Cooldown " + player.getSpecialSkillCooldown());
-        out.println("Items: " + formatInventory(inventory));
+        out.println("Items: " + formatInventory(player));
         out.println("Enemies:");
         for (Combatant enemy : livingEnemies) {
             List<String> activeStatuses = enemy.getActiveStatuses();
@@ -234,11 +233,11 @@ public class ConsoleBattleUi {
             + ", SPD " + combatant.getSpeed());
     }
 
-    private String formatInventory(Inventory inventory) {
+    private String formatInventory(PlayerCharacter player) {
         List<String> parts = new ArrayList<>();
         for (ItemType itemType : ItemType.values()) {
-            if (inventory.countOf(itemType) > 0) {
-                parts.add(itemType.getDisplayName() + " x" + inventory.countOf(itemType));
+            if (player.getInventory().countOf(itemType) > 0) {
+                parts.add(itemType.getDisplayName() + " x" + player.getInventory().countOf(itemType));
             }
         }
         if (parts.isEmpty()) {

--- a/src/main/java/sc2002/turnbased/ui/TurnBasedArenaCli.java
+++ b/src/main/java/sc2002/turnbased/ui/TurnBasedArenaCli.java
@@ -76,7 +76,7 @@ public class TurnBasedArenaCli {
             replaySameSettings = false;
 
             BattleSetup battleSetup = setupSupplier.get();
-            PlayerDecisionProvider decisionProvider = new CliPlayerDecisionProvider(ui, battleSetup.getInventory());
+            PlayerDecisionProvider decisionProvider = new CliPlayerDecisionProvider(ui);
             BattleEngine battleEngine = new BattleEngine(battleSetup, turnOrderStrategy);
             BattleEventListener battleEventListener = event -> ui.showBattleLines(formatter.format(List.of(event)));
             battleEngine.runUntilBattleEnds(decisionProvider, battleEventListener);

--- a/src/main/java/sc2002/turnbased/ui/gui/GuiPlayerDecisionProvider.java
+++ b/src/main/java/sc2002/turnbased/ui/gui/GuiPlayerDecisionProvider.java
@@ -29,11 +29,9 @@ import sc2002.turnbased.engine.PlayerDecisionProvider;
  */
 public class GuiPlayerDecisionProvider implements PlayerDecisionProvider {
     private final JFrame owner;
-    private final Inventory inventory;
 
-    public GuiPlayerDecisionProvider(JFrame owner, Inventory inventory) {
+    public GuiPlayerDecisionProvider(JFrame owner) {
         this.owner = owner;
-        this.inventory = inventory;
     }
 
     @Override
@@ -103,6 +101,7 @@ public class GuiPlayerDecisionProvider implements PlayerDecisionProvider {
     private PlayerDecision promptItemDecision(PlayerCharacter player, List<Combatant> livingEnemies) {
         AtomicReference<PlayerDecision> result = new AtomicReference<>();
         runOnEdt(() -> {
+            Inventory inventory = player.getInventory();
             List<ItemType> available = new ArrayList<>();
             for (ItemType itemType : ItemType.values()) {
                 if (inventory.countOf(itemType) > 0) {

--- a/src/main/java/sc2002/turnbased/ui/gui/TurnBasedArenaGui.java
+++ b/src/main/java/sc2002/turnbased/ui/gui/TurnBasedArenaGui.java
@@ -307,7 +307,7 @@ public class TurnBasedArenaGui extends JFrame {
         try {
             BattleSetup setup = setupSupplier.get();
             BattleEngine engine = new BattleEngine(setup, new SpeedTurnOrderStrategy());
-            GuiPlayerDecisionProvider decisions = new GuiPlayerDecisionProvider(this, setup.getInventory());
+            GuiPlayerDecisionProvider decisions = new GuiPlayerDecisionProvider(this);
             BattleEventListener listener = event -> SwingUtilities.invokeLater(() -> {
                 for (String line : formatter.format(List.of(event))) {
                     appendLog(line);

--- a/src/test/java/sc2002/turnbased/CustomGameModeVerifierTest.java
+++ b/src/test/java/sc2002/turnbased/CustomGameModeVerifierTest.java
@@ -197,8 +197,8 @@ class CustomGameModeVerifierTest {
         assertAll(
             () -> assertEquals(50, wizardSetup.getPlayer().getAttack()),
             () -> assertEquals(40, warriorSetup.getPlayer().getAttack()),
-            () -> assertEquals(1, wizardSetup.getInventory().countOf(ItemType.POTION)),
-            () -> assertEquals(1, wizardSetup.getInventory().countOf(ItemType.POWER_STONE))
+            () -> assertEquals(1, wizardSetup.getPlayer().getInventory().countOf(ItemType.POTION)),
+            () -> assertEquals(1, wizardSetup.getPlayer().getInventory().countOf(ItemType.POWER_STONE))
         );
     }
 

--- a/src/test/java/sc2002/turnbased/actions/UsePowerStoneSkillActionTest.java
+++ b/src/test/java/sc2002/turnbased/actions/UsePowerStoneSkillActionTest.java
@@ -1,0 +1,34 @@
+package sc2002.turnbased.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.support.TestActionExecutionContext;
+import sc2002.turnbased.support.TestCombatantBuilder;
+
+@Tag("unit")
+class UsePowerStoneSkillActionTest {
+    @Test
+    void execute_WhenActorIsNotAPlayerCharacter_DoesNotConsumePowerStoneBeforeThrowing() {
+        UsePowerStoneSkillAction action = new UsePowerStoneSkillAction();
+        Combatant actor = TestCombatantBuilder.aCombatant()
+            .named("Goblin")
+            .build();
+        actor.getInventory().add(ItemType.POWER_STONE, 1);
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> action.execute(new TestActionExecutionContext(List.of()), actor, null)
+        );
+
+        assertEquals("Power Stone is only supported for player characters", exception.getMessage());
+        assertEquals(1, actor.getInventory().countOf(ItemType.POWER_STONE));
+    }
+}

--- a/src/test/java/sc2002/turnbased/domain/CombatantTest.java
+++ b/src/test/java/sc2002/turnbased/domain/CombatantTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import sc2002.turnbased.domain.ItemType;
 import sc2002.turnbased.domain.status.ArcanePowerStatusEffect;
 import sc2002.turnbased.domain.status.CombatantStatusOutcome;
 import sc2002.turnbased.domain.status.DamageModifier;
@@ -83,6 +84,17 @@ class CombatantTest {
         assertEquals(20, defenseBeforeDefend);
         assertEquals(30, defenseDuringDefend);
         assertEquals(20, defenseAfterDefend);
+    }
+
+    @Test
+    void getInventory_WhenCombatantsOwnSeparateInventories_TracksItemsPerCombatant() {
+        PlayerCharacter warrior = TestDependencies.warrior();
+        PlayerCharacter wizard = TestDependencies.wizard();
+
+        warrior.getInventory().add(ItemType.POTION, 1);
+
+        assertEquals(1, warrior.getInventory().countOf(ItemType.POTION));
+        assertEquals(0, wizard.getInventory().countOf(ItemType.POTION));
     }
 
     @Test

--- a/src/test/java/sc2002/turnbased/engine/BattleEngineTest.java
+++ b/src/test/java/sc2002/turnbased/engine/BattleEngineTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import sc2002.turnbased.actions.BasicAttackAction;
 import sc2002.turnbased.domain.Combatant;
 import sc2002.turnbased.domain.EnemyCombatant;
-import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.PlayerCharacter;
 import sc2002.turnbased.domain.status.DefendStatusEffect;
 import sc2002.turnbased.domain.status.StatusEffect;
@@ -40,7 +39,7 @@ class BattleEngineTest {
         enemy.addStatusEffect(expiringOnTurnCheckEffect());
 
         BattleEngine battleEngine = new BattleEngine(
-            new BattleSetup(player, List.of(enemy), List.of(), new Inventory()),
+            new BattleSetup(player, List.of(enemy), List.of()),
             new SpeedTurnOrderStrategy()
         );
 
@@ -74,7 +73,7 @@ class BattleEngineTest {
             .build();
 
         BattleEngine battleEngine = new BattleEngine(
-            new BattleSetup(player, List.of(enemy), List.of(), new Inventory()),
+            new BattleSetup(player, List.of(enemy), List.of()),
             new SpeedTurnOrderStrategy()
         );
 

--- a/src/test/java/sc2002/turnbased/support/TestActionExecutionContext.java
+++ b/src/test/java/sc2002/turnbased/support/TestActionExecutionContext.java
@@ -5,19 +5,12 @@ import java.util.Objects;
 
 import sc2002.turnbased.actions.ActionExecutionContext;
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.Inventory;
 
 public final class TestActionExecutionContext implements ActionExecutionContext {
     private final List<Combatant> livingEnemies;
-    private final Inventory inventory;
 
     public TestActionExecutionContext(List<Combatant> livingEnemies) {
-        this(livingEnemies, new Inventory());
-    }
-
-    public TestActionExecutionContext(List<Combatant> livingEnemies, Inventory inventory) {
         this.livingEnemies = List.copyOf(Objects.requireNonNull(livingEnemies, "livingEnemies"));
-        this.inventory = Objects.requireNonNull(inventory, "inventory");
     }
 
     @Override
@@ -28,10 +21,5 @@ public final class TestActionExecutionContext implements ActionExecutionContext 
     @Override
     public List<Combatant> getLivingEnemiesInTurnOrder() {
         return livingEnemies;
-    }
-
-    @Override
-    public Inventory getInventory() {
-        return inventory;
     }
 }

--- a/src/test/java/sc2002/turnbased/ui/CliPlayerDecisionProviderTest.java
+++ b/src/test/java/sc2002/turnbased/ui/CliPlayerDecisionProviderTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 
 import sc2002.turnbased.actions.DefendAction;
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.Inventory;
 import sc2002.turnbased.domain.PlayerCharacter;
 import sc2002.turnbased.engine.PlayerDecision;
 import sc2002.turnbased.engine.TargetReference;
@@ -29,7 +28,7 @@ class CliPlayerDecisionProviderTest {
     void decide_WhenPromptingForPlayerAction_PresentsFourActionTypesAndReturnsSingleSelectedAction() {
         // arrange
         RecordingConsoleBattleUi ui = new RecordingConsoleBattleUi(1);
-        CliPlayerDecisionProvider provider = new CliPlayerDecisionProvider(ui, new Inventory());
+        CliPlayerDecisionProvider provider = new CliPlayerDecisionProvider(ui);
         PlayerCharacter warrior = TestDependencies.warrior();
         List<Combatant> livingEnemies = List.of(TestDependencies.goblin("Goblin"));
 
@@ -65,7 +64,7 @@ class CliPlayerDecisionProviderTest {
         }
 
         @Override
-        public void showPlayerTurn(int roundNumber, PlayerCharacter player, List<Combatant> livingEnemies, Inventory inventory) {
+        public void showPlayerTurn(int roundNumber, PlayerCharacter player, List<Combatant> livingEnemies) {
             showPlayerTurnCalls++;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Inventory now belongs to each combatant instead of a shared battle inventory; item consumption (potions, power stones, smoke bombs) is taken from the acting combatant.
  * UI and turn displays now read inventory from the player character; victory narration and item summaries reflect the player's personal inventory as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->