### PR TITLE
refactor(engine): split BattleEngine god class

### DIFF
--- a/src/main/java/sc2002/turnbased/engine/BattleEngine.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleEngine.java
@@ -15,20 +15,14 @@ public class BattleEngine implements ActionExecutionContext {
     private final WaveManager waveManager;
     private final RoundLifecycle roundLifecycle;
     private final BattleOutcomeReporter battleOutcomeReporter;
-    private final BattleEventPublisher battleEventPublisher;
 
     public BattleEngine(BattleSetup battleSetup, TurnOrderStrategy turnOrderStrategy) {
         this.battleState = new BattleState(battleSetup);
         this.turnOrderStrategy = turnOrderStrategy;
         this.turnProcessor = new DefaultTurnProcessor(battleState.player());
-        this.waveManager = new DefaultWaveManager(
-            battleState.initialEnemies(),
-            battleState.reserveEnemies(),
-            battleState.spawnedEnemies()
-        );
+        this.waveManager = new DefaultWaveManager(battleState);
         this.roundLifecycle = new DefaultRoundLifecycle(battleState.player(), battleState.spawnedEnemies());
         this.battleOutcomeReporter = new DefaultBattleOutcomeReporter(battleState.player());
-        this.battleEventPublisher = new BattleEventPublisher();
     }
 
     public List<BattleEvent> runRounds(int roundCount, PlayerDecisionProvider playerDecisionProvider) {
@@ -40,6 +34,7 @@ public class BattleEngine implements ActionExecutionContext {
         PlayerDecisionProvider playerDecisionProvider,
         BattleEventListener battleEventListener
     ) {
+        BattleEventPublisher battleEventPublisher = new BattleEventPublisher();
         Consumer<BattleEvent> emit = event -> battleEventPublisher.emit(event, battleEventListener);
         int roundsPlayed = 0;
         for (int roundNumber = 1; roundNumber <= roundCount; roundNumber++) {

--- a/src/main/java/sc2002/turnbased/engine/BattleEngine.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleEngine.java
@@ -1,36 +1,34 @@
 package sc2002.turnbased.engine;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import sc2002.turnbased.actions.ActionExecutionContext;
 import sc2002.turnbased.domain.Combatant;
-import sc2002.turnbased.domain.EnemyCombatant;
-import sc2002.turnbased.domain.ItemType;
-import sc2002.turnbased.domain.PlayerCharacter;
-import sc2002.turnbased.domain.status.CombatantStatusOutcome;
 import sc2002.turnbased.report.BattleEvent;
-import sc2002.turnbased.report.CombatantSummary;
-import sc2002.turnbased.report.NarrationEvent;
 import sc2002.turnbased.report.RoundStartEvent;
-import sc2002.turnbased.report.RoundSummaryEvent;
-import sc2002.turnbased.report.SkippedTurnEvent;
-import sc2002.turnbased.report.StatusEffectReportEvent;
 
 public class BattleEngine implements ActionExecutionContext {
-    private final PlayerCharacter player;
-    private final List<Combatant> initialEnemies;
-    private final List<Combatant> reserveEnemies;
-    private final List<Combatant> spawnedEnemies;
+    private final BattleState battleState;
     private final TurnOrderStrategy turnOrderStrategy;
-    private final List<BattleEvent> events = new ArrayList<>();
+    private final TurnProcessor turnProcessor;
+    private final WaveManager waveManager;
+    private final RoundLifecycle roundLifecycle;
+    private final BattleOutcomeReporter battleOutcomeReporter;
+    private final BattleEventPublisher battleEventPublisher;
 
     public BattleEngine(BattleSetup battleSetup, TurnOrderStrategy turnOrderStrategy) {
-        this.player = battleSetup.getPlayer();
-        this.initialEnemies = new ArrayList<>(battleSetup.getInitialEnemies());
-        this.reserveEnemies = new ArrayList<>(battleSetup.getBackupEnemies());
-        this.spawnedEnemies = new ArrayList<>(battleSetup.getInitialEnemies());
+        this.battleState = new BattleState(battleSetup);
         this.turnOrderStrategy = turnOrderStrategy;
+        this.turnProcessor = new DefaultTurnProcessor(battleState.player());
+        this.waveManager = new DefaultWaveManager(
+            battleState.initialEnemies(),
+            battleState.reserveEnemies(),
+            battleState.spawnedEnemies()
+        );
+        this.roundLifecycle = new DefaultRoundLifecycle(battleState.player(), battleState.spawnedEnemies());
+        this.battleOutcomeReporter = new DefaultBattleOutcomeReporter(battleState.player());
+        this.battleEventPublisher = new BattleEventPublisher();
     }
 
     public List<BattleEvent> runRounds(int roundCount, PlayerDecisionProvider playerDecisionProvider) {
@@ -42,33 +40,41 @@ public class BattleEngine implements ActionExecutionContext {
         PlayerDecisionProvider playerDecisionProvider,
         BattleEventListener battleEventListener
     ) {
+        Consumer<BattleEvent> emit = event -> battleEventPublisher.emit(event, battleEventListener);
         int roundsPlayed = 0;
         for (int roundNumber = 1; roundNumber <= roundCount; roundNumber++) {
-            emit(new RoundStartEvent(roundNumber), battleEventListener);
+            emit.accept(new RoundStartEvent(roundNumber));
             roundsPlayed = roundNumber;
 
-            List<Combatant> turnOrder = turnOrderStrategy.determineOrder(combatantsAliveAtRoundStart());
+            List<Combatant> turnOrder = turnOrderStrategy.determineOrder(battleState.combatantsAliveAtRoundStart());
             for (Combatant actor : turnOrder) {
-                if (isBattleOver()) {
+                if (battleState.isBattleOver()) {
                     break;
                 }
-                processTurn(roundNumber, actor, playerDecisionProvider, battleEventListener);
+                turnProcessor.processTurn(
+                    roundNumber,
+                    actor,
+                    playerDecisionProvider,
+                    this,
+                    emit
+                );
             }
 
-            spawnBackupIfNeeded(battleEventListener);
-            emit(createRoundSummary(roundNumber), battleEventListener);
-            completeRound(battleEventListener);
-            if (isBattleOver()) {
+            waveManager.spawnBackupIfNeeded(emit);
+            emit.accept(roundLifecycle.createRoundSummary(roundNumber));
+            roundLifecycle.completeRound(emit);
+            if (battleState.isBattleOver()) {
                 break;
             }
         }
 
-        if (player.isAlive() && livingEnemies().isEmpty() && reserveEnemies.isEmpty()) {
-            addVictoryNarration(roundsPlayed, battleEventListener);
-        } else if (!player.isAlive()) {
-            addDefeatNarration(roundsPlayed, battleEventListener);
-        }
-        return List.copyOf(events);
+        battleOutcomeReporter.reportOutcome(
+            roundsPlayed,
+            battleState.livingEnemies(),
+            battleState.reserveEnemies(),
+            emit
+        );
+        return battleEventPublisher.snapshot();
     }
 
     public List<BattleEvent> runUntilBattleEnds(PlayerDecisionProvider playerDecisionProvider) {
@@ -82,210 +88,13 @@ public class BattleEngine implements ActionExecutionContext {
         return runRounds(1000, playerDecisionProvider, battleEventListener);
     }
 
-    private void processTurn(
-        int roundNumber,
-        Combatant actor,
-        PlayerDecisionProvider playerDecisionProvider,
-        BattleEventListener battleEventListener
-    ) {
-        PlayerDecision decision = null;
-        if (actor == player && actor.isAlive()) {
-            decision = playerDecisionProvider.decide(roundNumber, player, livingEnemies());
-        }
-        if (shouldAdvanceCooldown(actor, decision)) {
-            player.advanceRoundState();
-        }
-
-        java.util.Optional<String> turnBlockReason = actor.getTurnBlockReason();
-        if (!actor.isAlive()) {
-            emit(
-                SkippedTurnEvent.fromStatusEffectOutcomes(
-                    actor,
-                    "ELIMINATED",
-                    actor.consumeStatusEffectOutcomes()
-                ),
-                battleEventListener
-            );
-            return;
-        }
-
-        if (turnBlockReason.isPresent()) {
-            emit(
-                SkippedTurnEvent.fromStatusEffectOutcomes(
-                    actor,
-                    turnBlockReason.get(),
-                    actor.consumeStatusEffectOutcomes()
-                ),
-                battleEventListener
-            );
-            return;
-        }
-
-        if (actor == player) {
-            processPlayerTurn(decision, battleEventListener);
-            return;
-        }
-
-        if (actor instanceof EnemyCombatant enemy) {
-            processEnemyTurn(enemy, battleEventListener);
-        }
-    }
-
-    private boolean shouldAdvanceCooldown(Combatant actor, PlayerDecision decision) {
-        return actor == player && decision != null && decision.action().advancesCooldown();
-    }
-
-    private void processPlayerTurn(PlayerDecision decision, BattleEventListener battleEventListener) {
-        Combatant target = decision.targetReference().resolveFrom(livingEnemies());
-        emitAll(decision.action().execute(this, player, target), battleEventListener);
-    }
-
-    private void processEnemyTurn(EnemyCombatant enemy, BattleEventListener battleEventListener) {
-        if (!player.isAlive()) {
-            return;
-        }
-        emitAll(enemy.takeTurn(this, player), battleEventListener);
-    }
-
-    private List<Combatant> combatantsAliveAtRoundStart() {
-        List<Combatant> combatants = new ArrayList<>();
-        if (player.isAlive()) {
-            combatants.add(player);
-        }
-        for (Combatant enemy : spawnedEnemies) {
-            if (enemy.isAlive()) {
-                combatants.add(enemy);
-            }
-        }
-        return combatants;
-    }
-
     @Override
     public List<Combatant> getLivingEnemies() {
-        return livingEnemies();
+        return battleState.livingEnemies();
     }
 
     @Override
     public List<Combatant> getLivingEnemiesInTurnOrder() {
-        return turnOrderStrategy.determineOrder(livingEnemies());
-    }
-
-    private List<Combatant> livingEnemies() {
-        List<Combatant> livingEnemies = new ArrayList<>();
-        for (Combatant enemy : spawnedEnemies) {
-            if (enemy.isAlive()) {
-                livingEnemies.add(enemy);
-            }
-        }
-        return livingEnemies;
-    }
-
-    private boolean isBattleOver() {
-        return !player.isAlive() || (livingEnemies().isEmpty() && reserveEnemies.isEmpty());
-    }
-
-    private void spawnBackupIfNeeded(BattleEventListener battleEventListener) {
-        if (!reserveEnemies.isEmpty() && initialWaveDefeated()) {
-            spawnedEnemies.addAll(reserveEnemies);
-            reserveEnemies.clear();
-            emit(new NarrationEvent("Backup Spawn triggered: " + spawnedEnemiesAfterInitialWave()), battleEventListener);
-        }
-    }
-
-    private boolean initialWaveDefeated() {
-        for (Combatant enemy : initialEnemies) {
-            if (enemy.isAlive()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private String spawnedEnemiesAfterInitialWave() {
-        List<String> names = new ArrayList<>();
-        for (Combatant enemy : spawnedEnemies) {
-            if (enemy.isAlive() && !initialEnemies.contains(enemy)) {
-                names.add(enemy.getName());
-            }
-        }
-        return String.join(", ", names);
-    }
-
-    private RoundSummaryEvent createRoundSummary(int roundNumber) {
-        List<CombatantSummary> enemySummaries = new ArrayList<>();
-        for (Combatant enemy : spawnedEnemies) {
-            enemySummaries.add(toSummary(enemy));
-        }
-        return new RoundSummaryEvent(
-            roundNumber,
-            toSummary(player),
-            enemySummaries,
-            player.getInventory().snapshot(),
-            player.getSpecialSkillCooldown()
-        );
-    }
-
-    private void completeRound(BattleEventListener battleEventListener) {
-        emitStatusEffectOutcomes(player.completeRound(), battleEventListener);
-        for (Combatant enemy : spawnedEnemies) {
-            emitStatusEffectOutcomes(enemy.completeRound(), battleEventListener);
-        }
-    }
-
-    private void emitStatusEffectOutcomes(
-        List<CombatantStatusOutcome> statusEffectOutcomes,
-        BattleEventListener battleEventListener
-    ) {
-        if (statusEffectOutcomes.isEmpty()) {
-            return;
-        }
-        emit(StatusEffectReportEvent.fromStatusEffectOutcomes(statusEffectOutcomes), battleEventListener);
-    }
-
-    private CombatantSummary toSummary(Combatant combatant) {
-        return new CombatantSummary(
-            combatant.combatantId(),
-            combatant.getName(),
-            combatant.getCurrentHp(),
-            combatant.getMaxHp(),
-            combatant.getAttack(),
-            combatant.getBaseAttack(),
-            combatant.isAlive(),
-            combatant.getActiveStatuses()
-        );
-    }
-
-    private void addVictoryNarration(int roundsPlayed, BattleEventListener battleEventListener) {
-        emit(new NarrationEvent("Victory:"), battleEventListener);
-        emit(new NarrationEvent("Remaining HP: " + player.getCurrentHp() + " / " + player.getMaxHp()), battleEventListener);
-        emit(new NarrationEvent("Total Rounds: " + roundsPlayed), battleEventListener);
-        for (ItemType itemType : player.getInventory().snapshot().keySet()) {
-            emit(
-                new NarrationEvent(
-                    "Remaining " + itemType.getDisplayName() + ": " + player.getInventory().countOf(itemType)
-                ),
-                battleEventListener
-            );
-        }
-        if (player.getAttack() != player.getBaseAttack()) {
-            emit(new NarrationEvent("Final " + player.getName() + " ATK: " + player.getAttack()), battleEventListener);
-        }
-    }
-
-    private void addDefeatNarration(int roundsPlayed, BattleEventListener battleEventListener) {
-        emit(new NarrationEvent("Defeat:"), battleEventListener);
-        emit(new NarrationEvent("Enemies remaining: " + livingEnemies().size()), battleEventListener);
-        emit(new NarrationEvent("Total Rounds Survived: " + roundsPlayed), battleEventListener);
-    }
-
-    private void emit(BattleEvent event, BattleEventListener battleEventListener) {
-        events.add(event);
-        battleEventListener.onEvent(event);
-    }
-
-    private void emitAll(List<BattleEvent> emittedEvents, BattleEventListener battleEventListener) {
-        for (BattleEvent emittedEvent : emittedEvents) {
-            emit(emittedEvent, battleEventListener);
-        }
+        return turnOrderStrategy.determineOrder(battleState.livingEnemies());
     }
 }

--- a/src/main/java/sc2002/turnbased/engine/BattleEventPublisher.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleEventPublisher.java
@@ -1,0 +1,19 @@
+package sc2002.turnbased.engine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sc2002.turnbased.report.BattleEvent;
+
+class BattleEventPublisher {
+    private final List<BattleEvent> events = new ArrayList<>();
+
+    void emit(BattleEvent battleEvent, BattleEventListener battleEventListener) {
+        events.add(battleEvent);
+        battleEventListener.onEvent(battleEvent);
+    }
+
+    List<BattleEvent> snapshot() {
+        return List.copyOf(events);
+    }
+}

--- a/src/main/java/sc2002/turnbased/engine/BattleOutcomeReporter.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleOutcomeReporter.java
@@ -1,0 +1,16 @@
+package sc2002.turnbased.engine;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.report.BattleEvent;
+
+interface BattleOutcomeReporter {
+    void reportOutcome(
+        int roundsPlayed,
+        List<Combatant> livingEnemies,
+        List<Combatant> reserveEnemies,
+        Consumer<BattleEvent> emit
+    );
+}

--- a/src/main/java/sc2002/turnbased/engine/BattleState.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleState.java
@@ -1,0 +1,60 @@
+package sc2002.turnbased.engine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+
+class BattleState {
+    private final PlayerCharacter player;
+    private final List<Combatant> initialEnemies;
+    private final List<Combatant> reserveEnemies;
+    private final List<Combatant> spawnedEnemies;
+
+    BattleState(BattleSetup battleSetup) {
+        this.player = battleSetup.getPlayer();
+        this.initialEnemies = new ArrayList<>(battleSetup.getInitialEnemies());
+        this.reserveEnemies = new ArrayList<>(battleSetup.getBackupEnemies());
+        this.spawnedEnemies = new ArrayList<>(battleSetup.getInitialEnemies());
+    }
+
+    PlayerCharacter player() {
+        return player;
+    }
+
+    List<Combatant> initialEnemies() {
+        return initialEnemies;
+    }
+
+    List<Combatant> reserveEnemies() {
+        return reserveEnemies;
+    }
+
+    List<Combatant> spawnedEnemies() {
+        return spawnedEnemies;
+    }
+
+    List<Combatant> combatantsAliveAtRoundStart() {
+        List<Combatant> combatants = new ArrayList<>();
+        if (player.isAlive()) {
+            combatants.add(player);
+        }
+        combatants.addAll(livingEnemies());
+        return combatants;
+    }
+
+    List<Combatant> livingEnemies() {
+        List<Combatant> livingEnemies = new ArrayList<>();
+        for (Combatant enemy : spawnedEnemies) {
+            if (enemy.isAlive()) {
+                livingEnemies.add(enemy);
+            }
+        }
+        return livingEnemies;
+    }
+
+    boolean isBattleOver() {
+        return !player.isAlive() || (livingEnemies().isEmpty() && reserveEnemies.isEmpty());
+    }
+}

--- a/src/main/java/sc2002/turnbased/engine/BattleState.java
+++ b/src/main/java/sc2002/turnbased/engine/BattleState.java
@@ -1,6 +1,7 @@
 package sc2002.turnbased.engine;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import sc2002.turnbased.domain.Combatant;
@@ -24,15 +25,20 @@ class BattleState {
     }
 
     List<Combatant> initialEnemies() {
-        return initialEnemies;
+        return Collections.unmodifiableList(initialEnemies);
     }
 
     List<Combatant> reserveEnemies() {
-        return reserveEnemies;
+        return Collections.unmodifiableList(reserveEnemies);
     }
 
     List<Combatant> spawnedEnemies() {
-        return spawnedEnemies;
+        return Collections.unmodifiableList(spawnedEnemies);
+    }
+
+    void moveAllReserveToSpawned() {
+        spawnedEnemies.addAll(reserveEnemies);
+        reserveEnemies.clear();
     }
 
     List<Combatant> combatantsAliveAtRoundStart() {

--- a/src/main/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporter.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporter.java
@@ -28,7 +28,8 @@ class DefaultBattleOutcomeReporter implements BattleOutcomeReporter {
             return;
         }
         if (!player.isAlive()) {
-            addDefeatNarration(roundsPlayed, livingEnemies.size(), emit);
+            int totalRemainingEnemies = livingEnemies.size() + reserveEnemies.size();
+            addDefeatNarration(roundsPlayed, totalRemainingEnemies, emit);
         }
     }
 
@@ -36,10 +37,11 @@ class DefaultBattleOutcomeReporter implements BattleOutcomeReporter {
         emit.accept(new NarrationEvent("Victory:"));
         emit.accept(new NarrationEvent("Remaining HP: " + player.getCurrentHp() + " / " + player.getMaxHp()));
         emit.accept(new NarrationEvent("Total Rounds: " + roundsPlayed));
-        for (ItemType itemType : player.getInventory().snapshot().keySet()) {
+        var inventorySnapshot = player.getInventory().snapshot();
+        for (ItemType itemType : inventorySnapshot.keySet()) {
             emit.accept(
                 new NarrationEvent(
-                    "Remaining " + itemType.getDisplayName() + ": " + player.getInventory().countOf(itemType)
+                    "Remaining " + itemType.getDisplayName() + ": " + inventorySnapshot.get(itemType)
                 )
             );
         }

--- a/src/main/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporter.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporter.java
@@ -1,0 +1,56 @@
+package sc2002.turnbased.engine;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.ItemType;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.NarrationEvent;
+
+class DefaultBattleOutcomeReporter implements BattleOutcomeReporter {
+    private final PlayerCharacter player;
+
+    DefaultBattleOutcomeReporter(PlayerCharacter player) {
+        this.player = player;
+    }
+
+    @Override
+    public void reportOutcome(
+        int roundsPlayed,
+        List<Combatant> livingEnemies,
+        List<Combatant> reserveEnemies,
+        Consumer<BattleEvent> emit
+    ) {
+        if (player.isAlive() && livingEnemies.isEmpty() && reserveEnemies.isEmpty()) {
+            addVictoryNarration(roundsPlayed, emit);
+            return;
+        }
+        if (!player.isAlive()) {
+            addDefeatNarration(roundsPlayed, livingEnemies.size(), emit);
+        }
+    }
+
+    private void addVictoryNarration(int roundsPlayed, Consumer<BattleEvent> emit) {
+        emit.accept(new NarrationEvent("Victory:"));
+        emit.accept(new NarrationEvent("Remaining HP: " + player.getCurrentHp() + " / " + player.getMaxHp()));
+        emit.accept(new NarrationEvent("Total Rounds: " + roundsPlayed));
+        for (ItemType itemType : player.getInventory().snapshot().keySet()) {
+            emit.accept(
+                new NarrationEvent(
+                    "Remaining " + itemType.getDisplayName() + ": " + player.getInventory().countOf(itemType)
+                )
+            );
+        }
+        if (player.getAttack() != player.getBaseAttack()) {
+            emit.accept(new NarrationEvent("Final " + player.getName() + " ATK: " + player.getAttack()));
+        }
+    }
+
+    private void addDefeatNarration(int roundsPlayed, int enemiesRemaining, Consumer<BattleEvent> emit) {
+        emit.accept(new NarrationEvent("Defeat:"));
+        emit.accept(new NarrationEvent("Enemies remaining: " + enemiesRemaining));
+        emit.accept(new NarrationEvent("Total Rounds Survived: " + roundsPlayed));
+    }
+}

--- a/src/main/java/sc2002/turnbased/engine/DefaultRoundLifecycle.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultRoundLifecycle.java
@@ -1,0 +1,69 @@
+package sc2002.turnbased.engine;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.domain.status.CombatantStatusOutcome;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.CombatantSummary;
+import sc2002.turnbased.report.RoundSummaryEvent;
+import sc2002.turnbased.report.StatusEffectReportEvent;
+
+class DefaultRoundLifecycle implements RoundLifecycle {
+    private final PlayerCharacter player;
+    private final List<Combatant> spawnedEnemies;
+
+    DefaultRoundLifecycle(PlayerCharacter player, List<Combatant> spawnedEnemies) {
+        this.player = player;
+        this.spawnedEnemies = spawnedEnemies;
+    }
+
+    @Override
+    public RoundSummaryEvent createRoundSummary(int roundNumber) {
+        List<CombatantSummary> enemySummaries = new ArrayList<>();
+        for (Combatant enemy : spawnedEnemies) {
+            enemySummaries.add(toSummary(enemy));
+        }
+        return new RoundSummaryEvent(
+            roundNumber,
+            toSummary(player),
+            enemySummaries,
+            player.getInventory().snapshot(),
+            player.getSpecialSkillCooldown()
+        );
+    }
+
+    @Override
+    public void completeRound(Consumer<BattleEvent> emit) {
+        emitStatusEffectOutcomes(player.completeRound(), emit);
+        for (Combatant enemy : spawnedEnemies) {
+            emitStatusEffectOutcomes(enemy.completeRound(), emit);
+        }
+    }
+
+    private void emitStatusEffectOutcomes(
+        List<CombatantStatusOutcome> statusEffectOutcomes,
+        Consumer<BattleEvent> emit
+    ) {
+        if (statusEffectOutcomes.isEmpty()) {
+            return;
+        }
+        emit.accept(StatusEffectReportEvent.fromStatusEffectOutcomes(statusEffectOutcomes));
+    }
+
+    private CombatantSummary toSummary(Combatant combatant) {
+        return new CombatantSummary(
+            combatant.combatantId(),
+            combatant.getName(),
+            combatant.getCurrentHp(),
+            combatant.getMaxHp(),
+            combatant.getAttack(),
+            combatant.getBaseAttack(),
+            combatant.isAlive(),
+            combatant.getActiveStatuses()
+        );
+    }
+}

--- a/src/main/java/sc2002/turnbased/engine/DefaultTurnProcessor.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultTurnProcessor.java
@@ -25,6 +25,8 @@ class DefaultTurnProcessor implements TurnProcessor {
         ActionExecutionContext actionExecutionContext,
         Consumer<BattleEvent> emit
     ) {
+        Optional<String> turnBlockReason = actor.getTurnBlockReason();
+
         if (!actor.isAlive()) {
             emit.accept(
                 SkippedTurnEvent.fromStatusEffectOutcomes(
@@ -36,7 +38,6 @@ class DefaultTurnProcessor implements TurnProcessor {
             return;
         }
 
-        Optional<String> turnBlockReason = actor.getTurnBlockReason();
         if (turnBlockReason.isPresent()) {
             emit.accept(
                 SkippedTurnEvent.fromStatusEffectOutcomes(

--- a/src/main/java/sc2002/turnbased/engine/DefaultTurnProcessor.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultTurnProcessor.java
@@ -25,15 +25,6 @@ class DefaultTurnProcessor implements TurnProcessor {
         ActionExecutionContext actionExecutionContext,
         Consumer<BattleEvent> emit
     ) {
-        PlayerDecision decision = null;
-        if (actor == player && actor.isAlive()) {
-            decision = playerDecisionProvider.decide(roundNumber, player, actionExecutionContext.getLivingEnemies());
-        }
-        if (shouldAdvanceCooldown(actor, decision)) {
-            player.advanceRoundState();
-        }
-
-        Optional<String> turnBlockReason = actor.getTurnBlockReason();
         if (!actor.isAlive()) {
             emit.accept(
                 SkippedTurnEvent.fromStatusEffectOutcomes(
@@ -45,6 +36,7 @@ class DefaultTurnProcessor implements TurnProcessor {
             return;
         }
 
+        Optional<String> turnBlockReason = actor.getTurnBlockReason();
         if (turnBlockReason.isPresent()) {
             emit.accept(
                 SkippedTurnEvent.fromStatusEffectOutcomes(
@@ -57,6 +49,14 @@ class DefaultTurnProcessor implements TurnProcessor {
         }
 
         if (actor == player) {
+            PlayerDecision decision = playerDecisionProvider.decide(
+                roundNumber,
+                player,
+                actionExecutionContext.getLivingEnemies()
+            );
+            if (shouldAdvanceCooldown(decision)) {
+                player.advanceRoundState();
+            }
             processPlayerTurn(decision, actionExecutionContext, emit);
             return;
         }
@@ -66,8 +66,8 @@ class DefaultTurnProcessor implements TurnProcessor {
         }
     }
 
-    private boolean shouldAdvanceCooldown(Combatant actor, PlayerDecision decision) {
-        return actor == player && decision != null && decision.action().advancesCooldown();
+    private boolean shouldAdvanceCooldown(PlayerDecision decision) {
+        return decision != null && decision.action().advancesCooldown();
     }
 
     private void processPlayerTurn(

--- a/src/main/java/sc2002/turnbased/engine/DefaultTurnProcessor.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultTurnProcessor.java
@@ -1,0 +1,96 @@
+package sc2002.turnbased.engine;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import sc2002.turnbased.actions.ActionExecutionContext;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.SkippedTurnEvent;
+
+class DefaultTurnProcessor implements TurnProcessor {
+    private final PlayerCharacter player;
+
+    DefaultTurnProcessor(PlayerCharacter player) {
+        this.player = player;
+    }
+
+    @Override
+    public void processTurn(
+        int roundNumber,
+        Combatant actor,
+        PlayerDecisionProvider playerDecisionProvider,
+        ActionExecutionContext actionExecutionContext,
+        Consumer<BattleEvent> emit
+    ) {
+        PlayerDecision decision = null;
+        if (actor == player && actor.isAlive()) {
+            decision = playerDecisionProvider.decide(roundNumber, player, actionExecutionContext.getLivingEnemies());
+        }
+        if (shouldAdvanceCooldown(actor, decision)) {
+            player.advanceRoundState();
+        }
+
+        Optional<String> turnBlockReason = actor.getTurnBlockReason();
+        if (!actor.isAlive()) {
+            emit.accept(
+                SkippedTurnEvent.fromStatusEffectOutcomes(
+                    actor,
+                    "ELIMINATED",
+                    actor.consumeStatusEffectOutcomes()
+                )
+            );
+            return;
+        }
+
+        if (turnBlockReason.isPresent()) {
+            emit.accept(
+                SkippedTurnEvent.fromStatusEffectOutcomes(
+                    actor,
+                    turnBlockReason.get(),
+                    actor.consumeStatusEffectOutcomes()
+                )
+            );
+            return;
+        }
+
+        if (actor == player) {
+            processPlayerTurn(decision, actionExecutionContext, emit);
+            return;
+        }
+
+        if (actor instanceof EnemyCombatant enemy) {
+            processEnemyTurn(enemy, actionExecutionContext, emit);
+        }
+    }
+
+    private boolean shouldAdvanceCooldown(Combatant actor, PlayerDecision decision) {
+        return actor == player && decision != null && decision.action().advancesCooldown();
+    }
+
+    private void processPlayerTurn(
+        PlayerDecision decision,
+        ActionExecutionContext actionExecutionContext,
+        Consumer<BattleEvent> emit
+    ) {
+        Combatant target = decision.targetReference().resolveFrom(actionExecutionContext.getLivingEnemies());
+        for (BattleEvent battleEvent : decision.action().execute(actionExecutionContext, player, target)) {
+            emit.accept(battleEvent);
+        }
+    }
+
+    private void processEnemyTurn(
+        EnemyCombatant enemy,
+        ActionExecutionContext actionExecutionContext,
+        Consumer<BattleEvent> emit
+    ) {
+        if (!player.isAlive()) {
+            return;
+        }
+        for (BattleEvent battleEvent : enemy.takeTurn(actionExecutionContext, player)) {
+            emit.accept(battleEvent);
+        }
+    }
+}

--- a/src/main/java/sc2002/turnbased/engine/DefaultWaveManager.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultWaveManager.java
@@ -2,6 +2,7 @@ package sc2002.turnbased.engine;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import sc2002.turnbased.domain.Combatant;
@@ -11,20 +12,43 @@ import sc2002.turnbased.report.NarrationEvent;
 class DefaultWaveManager implements WaveManager {
     private final List<Combatant> initialEnemies;
     private final List<Combatant> reserveEnemies;
-    private final List<Combatant> spawnedEnemies;
+    private final Runnable moveReserveToSpawned;
+
+    DefaultWaveManager(BattleState battleState) {
+        this(
+            battleState.initialEnemies(),
+            battleState.reserveEnemies(),
+            battleState::moveAllReserveToSpawned
+        );
+    }
 
     DefaultWaveManager(List<Combatant> initialEnemies, List<Combatant> reserveEnemies, List<Combatant> spawnedEnemies) {
-        this.initialEnemies = initialEnemies;
-        this.reserveEnemies = reserveEnemies;
-        this.spawnedEnemies = spawnedEnemies;
+        this(
+            initialEnemies,
+            reserveEnemies,
+            () -> {
+                spawnedEnemies.addAll(reserveEnemies);
+                reserveEnemies.clear();
+            }
+        );
+    }
+
+    private DefaultWaveManager(
+        List<Combatant> initialEnemies,
+        List<Combatant> reserveEnemies,
+        Runnable moveReserveToSpawned
+    ) {
+        this.initialEnemies = Objects.requireNonNull(initialEnemies, "initialEnemies");
+        this.reserveEnemies = Objects.requireNonNull(reserveEnemies, "reserveEnemies");
+        this.moveReserveToSpawned = Objects.requireNonNull(moveReserveToSpawned, "moveReserveToSpawned");
     }
 
     @Override
     public void spawnBackupIfNeeded(Consumer<BattleEvent> emit) {
         if (!reserveEnemies.isEmpty() && initialWaveDefeated()) {
-            spawnedEnemies.addAll(reserveEnemies);
-            reserveEnemies.clear();
-            emit.accept(new NarrationEvent("Backup Spawn triggered: " + spawnedEnemiesAfterInitialWave()));
+            String backupNames = reserveEnemyNamesToSpawn();
+            moveReserveToSpawned.run();
+            emit.accept(new NarrationEvent("Backup Spawn triggered: " + backupNames));
         }
     }
 
@@ -37,9 +61,9 @@ class DefaultWaveManager implements WaveManager {
         return true;
     }
 
-    private String spawnedEnemiesAfterInitialWave() {
+    private String reserveEnemyNamesToSpawn() {
         List<String> names = new ArrayList<>();
-        for (Combatant enemy : spawnedEnemies) {
+        for (Combatant enemy : reserveEnemies) {
             if (enemy.isAlive() && !initialEnemies.contains(enemy)) {
                 names.add(enemy.getName());
             }

--- a/src/main/java/sc2002/turnbased/engine/DefaultWaveManager.java
+++ b/src/main/java/sc2002/turnbased/engine/DefaultWaveManager.java
@@ -1,0 +1,49 @@
+package sc2002.turnbased.engine;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.NarrationEvent;
+
+class DefaultWaveManager implements WaveManager {
+    private final List<Combatant> initialEnemies;
+    private final List<Combatant> reserveEnemies;
+    private final List<Combatant> spawnedEnemies;
+
+    DefaultWaveManager(List<Combatant> initialEnemies, List<Combatant> reserveEnemies, List<Combatant> spawnedEnemies) {
+        this.initialEnemies = initialEnemies;
+        this.reserveEnemies = reserveEnemies;
+        this.spawnedEnemies = spawnedEnemies;
+    }
+
+    @Override
+    public void spawnBackupIfNeeded(Consumer<BattleEvent> emit) {
+        if (!reserveEnemies.isEmpty() && initialWaveDefeated()) {
+            spawnedEnemies.addAll(reserveEnemies);
+            reserveEnemies.clear();
+            emit.accept(new NarrationEvent("Backup Spawn triggered: " + spawnedEnemiesAfterInitialWave()));
+        }
+    }
+
+    private boolean initialWaveDefeated() {
+        for (Combatant enemy : initialEnemies) {
+            if (enemy.isAlive()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String spawnedEnemiesAfterInitialWave() {
+        List<String> names = new ArrayList<>();
+        for (Combatant enemy : spawnedEnemies) {
+            if (enemy.isAlive() && !initialEnemies.contains(enemy)) {
+                names.add(enemy.getName());
+            }
+        }
+        return String.join(", ", names);
+    }
+}

--- a/src/main/java/sc2002/turnbased/engine/RoundLifecycle.java
+++ b/src/main/java/sc2002/turnbased/engine/RoundLifecycle.java
@@ -1,0 +1,12 @@
+package sc2002.turnbased.engine;
+
+import java.util.function.Consumer;
+
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.RoundSummaryEvent;
+
+interface RoundLifecycle {
+    RoundSummaryEvent createRoundSummary(int roundNumber);
+
+    void completeRound(Consumer<BattleEvent> emit);
+}

--- a/src/main/java/sc2002/turnbased/engine/TurnProcessor.java
+++ b/src/main/java/sc2002/turnbased/engine/TurnProcessor.java
@@ -1,0 +1,17 @@
+package sc2002.turnbased.engine;
+
+import java.util.function.Consumer;
+
+import sc2002.turnbased.actions.ActionExecutionContext;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.report.BattleEvent;
+
+interface TurnProcessor {
+    void processTurn(
+        int roundNumber,
+        Combatant actor,
+        PlayerDecisionProvider playerDecisionProvider,
+        ActionExecutionContext actionExecutionContext,
+        Consumer<BattleEvent> emit
+    );
+}

--- a/src/main/java/sc2002/turnbased/engine/WaveManager.java
+++ b/src/main/java/sc2002/turnbased/engine/WaveManager.java
@@ -1,0 +1,9 @@
+package sc2002.turnbased.engine;
+
+import java.util.function.Consumer;
+
+import sc2002.turnbased.report.BattleEvent;
+
+interface WaveManager {
+    void spawnBackupIfNeeded(Consumer<BattleEvent> emit);
+}

--- a/src/test/java/sc2002/turnbased/engine/BattleEngineEventStreamConsistencyTest.java
+++ b/src/test/java/sc2002/turnbased/engine/BattleEngineEventStreamConsistencyTest.java
@@ -44,6 +44,38 @@ class BattleEngineEventStreamConsistencyTest {
     }
 
     @Test
+    void runRounds_WhenInvokedTwiceOnSameEngine_EventStreamsDoNotCarryOverBetweenRuns() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Training Goblin")
+            .withHp(300)
+            .withAttack(0)
+            .build();
+
+        BattleEngine battleEngine = new BattleEngine(
+            new BattleSetup(player, List.of(enemy), List.of()),
+            new SpeedTurnOrderStrategy()
+        );
+
+        ScriptedDecisionProvider decisions = new ScriptedDecisionProvider()
+            .addDecision(1, PlayerDecision.targeted(new BasicAttackAction(), enemy));
+        List<BattleEvent> observedByListener = new ArrayList<>();
+
+        List<BattleEvent> firstReturnedEvents = battleEngine.runRounds(1, decisions, observedByListener::add);
+        List<BattleEvent> firstObservedByListener = List.copyOf(observedByListener);
+
+        List<BattleEvent> secondReturnedEvents = battleEngine.runRounds(1, decisions, observedByListener::add);
+        List<BattleEvent> secondObservedByListener = List.copyOf(
+            observedByListener.subList(firstObservedByListener.size(), observedByListener.size())
+        );
+
+        assertFalse(firstReturnedEvents.isEmpty());
+        assertFalse(secondReturnedEvents.isEmpty());
+        assertEquals(firstReturnedEvents, firstObservedByListener);
+        assertEquals(secondReturnedEvents, secondObservedByListener);
+    }
+
+    @Test
     void runUntilBattleEnds_WhenListenerIsProvided_ListenerStreamMatchesReturnedEvents() {
         PlayerCharacter player = TestDependencies.warrior();
         EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())

--- a/src/test/java/sc2002/turnbased/engine/BattleEngineEventStreamConsistencyTest.java
+++ b/src/test/java/sc2002/turnbased/engine/BattleEngineEventStreamConsistencyTest.java
@@ -1,0 +1,75 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.support.TestDependencies;
+import sc2002.turnbased.support.TestEnemyCombatantBuilder;
+
+@Tag("integration")
+class BattleEngineEventStreamConsistencyTest {
+    @Test
+    void runRounds_WhenListenerIsProvided_ListenerStreamMatchesReturnedEvents() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Goblin")
+            .withHp(60)
+            .build();
+
+        BattleEngine battleEngine = new BattleEngine(
+            new BattleSetup(player, List.of(enemy), List.of()),
+            new SpeedTurnOrderStrategy()
+        );
+
+        List<BattleEvent> observedByListener = new ArrayList<>();
+        List<BattleEvent> returnedEvents = battleEngine.runRounds(
+            1,
+            new ScriptedDecisionProvider().addDecision(1, PlayerDecision.targeted(new BasicAttackAction(), enemy)),
+            observedByListener::add
+        );
+
+        assertFalse(returnedEvents.isEmpty());
+        assertEquals(returnedEvents, observedByListener);
+    }
+
+    @Test
+    void runUntilBattleEnds_WhenListenerIsProvided_ListenerStreamMatchesReturnedEvents() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Weak Goblin")
+            .withHp(1)
+            .withDefense(0)
+            .build();
+
+        BattleEngine battleEngine = new BattleEngine(
+            new BattleSetup(player, List.of(enemy), List.of()),
+            new SpeedTurnOrderStrategy()
+        );
+
+        List<BattleEvent> observedByListener = new ArrayList<>();
+        PlayerDecisionProvider decisions = (roundNumber, actor, livingEnemies) ->
+            PlayerDecision.targeted(new BasicAttackAction(), firstEnemy(livingEnemies));
+
+        List<BattleEvent> returnedEvents = battleEngine.runUntilBattleEnds(decisions, observedByListener::add);
+
+        assertFalse(returnedEvents.isEmpty());
+        assertEquals(returnedEvents, observedByListener);
+    }
+
+    private static Combatant firstEnemy(List<Combatant> livingEnemies) {
+        return livingEnemies.stream()
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected at least one living enemy"));
+    }
+}

--- a/src/test/java/sc2002/turnbased/engine/BattleEventPublisherTest.java
+++ b/src/test/java/sc2002/turnbased/engine/BattleEventPublisherTest.java
@@ -1,0 +1,42 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.NarrationEvent;
+
+@Tag("unit")
+class BattleEventPublisherTest {
+    @Test
+    void emit_WhenCalled_StoresEventAndNotifiesListener() {
+        BattleEventPublisher battleEventPublisher = new BattleEventPublisher();
+        List<BattleEvent> observedByListener = new ArrayList<>();
+        NarrationEvent event = new NarrationEvent("Test Event");
+
+        battleEventPublisher.emit(event, observedByListener::add);
+
+        assertEquals(List.of(event), observedByListener);
+        assertEquals(List.of(event), battleEventPublisher.snapshot());
+    }
+
+    @Test
+    void snapshot_WhenMutated_ThrowsUnsupportedOperationException() {
+        BattleEventPublisher battleEventPublisher = new BattleEventPublisher();
+        battleEventPublisher.emit(new NarrationEvent("Immutable"), BattleEventListener.NO_OP);
+
+        List<BattleEvent> snapshot = battleEventPublisher.snapshot();
+
+        UnsupportedOperationException exception = assertThrows(
+            UnsupportedOperationException.class,
+            () -> snapshot.add(new NarrationEvent("Fail"))
+        );
+        assertEquals(UnsupportedOperationException.class, exception.getClass());
+    }
+}

--- a/src/test/java/sc2002/turnbased/engine/BattleEventPublisherTest.java
+++ b/src/test/java/sc2002/turnbased/engine/BattleEventPublisherTest.java
@@ -1,6 +1,7 @@
 package sc2002.turnbased.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -37,6 +38,6 @@ class BattleEventPublisherTest {
             UnsupportedOperationException.class,
             () -> snapshot.add(new NarrationEvent("Fail"))
         );
-        assertEquals(UnsupportedOperationException.class, exception.getClass());
+        assertNotNull(exception);
     }
 }

--- a/src/test/java/sc2002/turnbased/engine/BattleStateTest.java
+++ b/src/test/java/sc2002/turnbased/engine/BattleStateTest.java
@@ -1,0 +1,68 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.support.TestDependencies;
+import sc2002.turnbased.support.TestEnemyCombatantBuilder;
+
+@Tag("unit")
+class BattleStateTest {
+    @Test
+    void combatantsAliveAtRoundStart_WhenCalled_IncludesPlayerAndLivingEnemiesOnly() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant aliveEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Alive Goblin")
+            .withHp(30)
+            .build();
+        EnemyCombatant deadEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Dead Goblin")
+            .withCurrentHp(0)
+            .withMaxHp(30)
+            .build();
+
+        BattleState battleState = new BattleState(new BattleSetup(player, List.of(aliveEnemy, deadEnemy), List.of()));
+
+        List<Combatant> combatants = battleState.combatantsAliveAtRoundStart();
+
+        assertEquals(List.of(player, aliveEnemy), combatants);
+    }
+
+    @Test
+    void isBattleOver_WhenOnlyReserveEnemiesRemain_ReturnsFalse() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant deadInitialEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Dead Initial")
+            .withCurrentHp(0)
+            .withMaxHp(30)
+            .build();
+        EnemyCombatant reserveEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Reserve")
+            .withHp(20)
+            .build();
+
+        BattleState battleState = new BattleState(new BattleSetup(player, List.of(deadInitialEnemy), List.of(reserveEnemy)));
+
+        assertFalse(battleState.isBattleOver());
+    }
+
+    @Test
+    void isBattleOver_WhenPlayerIsDefeated_ReturnsTrue() {
+        PlayerCharacter player = TestDependencies.warrior();
+        player.receiveDamage(player.getCurrentHp());
+
+        BattleState battleState = new BattleState(new BattleSetup(player, List.of(), List.of()));
+
+        assertTrue(battleState.isBattleOver());
+    }
+}

--- a/src/test/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporterTest.java
+++ b/src/test/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporterTest.java
@@ -52,6 +52,26 @@ class DefaultBattleOutcomeReporterTest {
         assertTrue(narrationLines.contains("Total Rounds Survived: 3"));
     }
 
+    @Test
+    void reportOutcome_WhenOnlyReserveEnemiesRemainOnDefeat_UsesTotalRemainingEnemyCount() {
+        PlayerCharacter player = TestDependencies.warrior();
+        player.receiveDamage(player.getCurrentHp());
+        EnemyCombatant reserveEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Reserve Wolf")
+            .withHp(40)
+            .build();
+
+        BattleOutcomeReporter reporter = new DefaultBattleOutcomeReporter(player);
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        reporter.reportOutcome(3, List.of(), List.of(reserveEnemy), emittedEvents::add);
+
+        List<String> narrationLines = narrationTexts(emittedEvents);
+        assertTrue(narrationLines.contains("Defeat:"));
+        assertTrue(narrationLines.contains("Enemies remaining: 1"));
+        assertTrue(narrationLines.contains("Total Rounds Survived: 3"));
+    }
+
     private static List<String> narrationTexts(List<BattleEvent> events) {
         List<String> lines = new ArrayList<>();
         for (BattleEvent event : events) {

--- a/src/test/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporterTest.java
+++ b/src/test/java/sc2002/turnbased/engine/DefaultBattleOutcomeReporterTest.java
@@ -1,0 +1,64 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.NarrationEvent;
+import sc2002.turnbased.support.TestDependencies;
+import sc2002.turnbased.support.TestEnemyCombatantBuilder;
+
+@Tag("unit")
+class DefaultBattleOutcomeReporterTest {
+    @Test
+    void reportOutcome_WhenVictory_EmitsVictoryNarration() {
+        PlayerCharacter player = TestDependencies.warrior();
+        BattleOutcomeReporter reporter = new DefaultBattleOutcomeReporter(player);
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        reporter.reportOutcome(4, List.of(), List.of(), emittedEvents::add);
+
+        List<String> narrationLines = narrationTexts(emittedEvents);
+        assertTrue(narrationLines.contains("Victory:"));
+        assertTrue(narrationLines.contains("Total Rounds: 4"));
+        assertTrue(narrationLines.stream().anyMatch(line -> line.startsWith("Remaining HP: ")));
+    }
+
+    @Test
+    void reportOutcome_WhenDefeat_EmitsDefeatNarration() {
+        PlayerCharacter player = TestDependencies.warrior();
+        player.receiveDamage(player.getCurrentHp());
+        EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Wolf")
+            .withHp(40)
+            .build();
+
+        BattleOutcomeReporter reporter = new DefaultBattleOutcomeReporter(player);
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        reporter.reportOutcome(3, List.of(enemy), List.of(), emittedEvents::add);
+
+        List<String> narrationLines = narrationTexts(emittedEvents);
+        assertTrue(narrationLines.contains("Defeat:"));
+        assertTrue(narrationLines.contains("Enemies remaining: 1"));
+        assertTrue(narrationLines.contains("Total Rounds Survived: 3"));
+    }
+
+    private static List<String> narrationTexts(List<BattleEvent> events) {
+        List<String> lines = new ArrayList<>();
+        for (BattleEvent event : events) {
+            if (event instanceof NarrationEvent narrationEvent) {
+                lines.add(narrationEvent.getText());
+            }
+        }
+        return lines;
+    }
+}

--- a/src/test/java/sc2002/turnbased/engine/DefaultRoundLifecycleTest.java
+++ b/src/test/java/sc2002/turnbased/engine/DefaultRoundLifecycleTest.java
@@ -1,0 +1,71 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.domain.status.DefendStatusEffect;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.CombatantSummary;
+import sc2002.turnbased.report.RoundSummaryEvent;
+import sc2002.turnbased.report.StatusEffectReportEvent;
+import sc2002.turnbased.support.TestDependencies;
+import sc2002.turnbased.support.TestEnemyCombatantBuilder;
+
+@Tag("unit")
+class DefaultRoundLifecycleTest {
+    @Test
+    void createRoundSummary_WhenCalled_IncludesPlayerAndAllSpawnedEnemies() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant aliveEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Alive Goblin")
+            .withHp(30)
+            .build();
+        EnemyCombatant deadEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Dead Goblin")
+            .withCurrentHp(0)
+            .withMaxHp(30)
+            .build();
+
+        List<Combatant> spawnedEnemies = List.of(aliveEnemy, deadEnemy);
+        RoundLifecycle roundLifecycle = new DefaultRoundLifecycle(player, spawnedEnemies);
+
+        RoundSummaryEvent summaryEvent = roundLifecycle.createRoundSummary(2);
+
+        assertEquals(2, summaryEvent.getRoundNumber());
+        assertEquals(player.getName(), summaryEvent.getPlayerSummary().getName());
+        assertEquals(2, summaryEvent.getEnemySummaries().size());
+
+        CombatantSummary deadEnemySummary = summaryEvent.getEnemySummaries().stream()
+            .filter(enemy -> enemy.getName().equals("Dead Goblin"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected dead enemy summary"));
+        assertFalse(deadEnemySummary.isAlive());
+    }
+
+    @Test
+    void completeRound_WhenStatusEffectExpires_EmitsStatusEffectReport() {
+        PlayerCharacter player = TestDependencies.warrior();
+        player.addStatusEffect(new DefendStatusEffect(1));
+
+        RoundLifecycle roundLifecycle = new DefaultRoundLifecycle(player, List.of());
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        roundLifecycle.completeRound(emittedEvents::add);
+
+        assertEquals(1, emittedEvents.size());
+        StatusEffectReportEvent reportEvent = assertInstanceOf(StatusEffectReportEvent.class, emittedEvents.get(0));
+        assertTrue(reportEvent.statusEffectNotes().contains("Defend expired"));
+    }
+}

--- a/src/test/java/sc2002/turnbased/engine/DefaultTurnProcessorTest.java
+++ b/src/test/java/sc2002/turnbased/engine/DefaultTurnProcessorTest.java
@@ -1,0 +1,66 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.actions.ActionExecutionContext;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.domain.PlayerCharacter;
+import sc2002.turnbased.domain.status.StunStatusEffect;
+import sc2002.turnbased.report.ActionEvent;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.SkippedTurnEvent;
+import sc2002.turnbased.support.TestActionExecutionContext;
+import sc2002.turnbased.support.TestDependencies;
+import sc2002.turnbased.support.TestEnemyCombatantBuilder;
+
+@Tag("unit")
+class DefaultTurnProcessorTest {
+    @Test
+    void processTurn_WhenPlayerActs_EmitsActionEvent() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Goblin")
+            .withHp(60)
+            .build();
+
+        TurnProcessor turnProcessor = new DefaultTurnProcessor(player);
+        PlayerDecisionProvider decisions = new ScriptedDecisionProvider()
+            .addDecision(1, PlayerDecision.targeted(new BasicAttackAction(), enemy));
+        ActionExecutionContext context = new TestActionExecutionContext(List.of(enemy));
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        turnProcessor.processTurn(1, player, decisions, context, emittedEvents::add);
+
+        ActionEvent actionEvent = assertInstanceOf(ActionEvent.class, emittedEvents.get(0));
+        assertEquals(player.getName(), actionEvent.getActorName());
+        assertEquals(enemy.getName(), actionEvent.getTargetName());
+    }
+
+    @Test
+    void processTurn_WhenEnemyIsStunned_EmitsSkippedTurnEvent() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant stunnedEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Stunned Goblin")
+            .withHp(50)
+            .build();
+        stunnedEnemy.addStatusEffect(new StunStatusEffect(1));
+
+        TurnProcessor turnProcessor = new DefaultTurnProcessor(player);
+        ActionExecutionContext context = new TestActionExecutionContext(List.of(stunnedEnemy));
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        turnProcessor.processTurn(1, stunnedEnemy, new ScriptedDecisionProvider(), context, emittedEvents::add);
+
+        SkippedTurnEvent skippedTurnEvent = assertInstanceOf(SkippedTurnEvent.class, emittedEvents.get(0));
+        assertEquals("STUNNED", skippedTurnEvent.getReason());
+        assertEquals(stunnedEnemy.getName(), skippedTurnEvent.getCombatantName());
+    }
+}

--- a/src/test/java/sc2002/turnbased/engine/DefaultTurnProcessorTest.java
+++ b/src/test/java/sc2002/turnbased/engine/DefaultTurnProcessorTest.java
@@ -2,6 +2,7 @@ package sc2002.turnbased.engine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,5 +63,40 @@ class DefaultTurnProcessorTest {
         SkippedTurnEvent skippedTurnEvent = assertInstanceOf(SkippedTurnEvent.class, emittedEvents.get(0));
         assertEquals("STUNNED", skippedTurnEvent.getReason());
         assertEquals(stunnedEnemy.getName(), skippedTurnEvent.getCombatantName());
+    }
+
+    @Test
+    void processTurn_WhenPlayerIsTurnBlocked_DoesNotConsumeDecisionOrAdvanceCooldown() {
+        PlayerCharacter player = TestDependencies.warrior();
+        EnemyCombatant enemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Goblin")
+            .withHp(80)
+            .build();
+
+        ActionExecutionContext context = new TestActionExecutionContext(List.of(enemy));
+        player.useSpecialSkill(context, enemy);
+        int cooldownBefore = player.getSpecialSkillCooldown();
+        assertTrue(cooldownBefore > 0);
+
+        player.addStatusEffect(new StunStatusEffect(2));
+        List<String> activeStatusesBefore = player.getActiveStatuses();
+
+        int[] decisionCalls = new int[] {0};
+        PlayerDecisionProvider decisions = (roundNumber, actingPlayer, livingEnemies) -> {
+            decisionCalls[0]++;
+            return PlayerDecision.targeted(new BasicAttackAction(), enemy);
+        };
+
+        TurnProcessor turnProcessor = new DefaultTurnProcessor(player);
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        turnProcessor.processTurn(1, player, decisions, context, emittedEvents::add);
+
+        SkippedTurnEvent skippedTurnEvent = assertInstanceOf(SkippedTurnEvent.class, emittedEvents.get(0));
+        assertEquals("STUNNED", skippedTurnEvent.getReason());
+        assertEquals(player.getName(), skippedTurnEvent.getCombatantName());
+        assertEquals(0, decisionCalls[0]);
+        assertEquals(cooldownBefore, player.getSpecialSkillCooldown());
+        assertEquals(activeStatusesBefore, player.getActiveStatuses());
     }
 }

--- a/src/test/java/sc2002/turnbased/engine/DefaultWaveManagerTest.java
+++ b/src/test/java/sc2002/turnbased/engine/DefaultWaveManagerTest.java
@@ -1,0 +1,75 @@
+package sc2002.turnbased.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import sc2002.turnbased.actions.BasicAttackAction;
+import sc2002.turnbased.domain.Combatant;
+import sc2002.turnbased.domain.EnemyCombatant;
+import sc2002.turnbased.report.BattleEvent;
+import sc2002.turnbased.report.NarrationEvent;
+import sc2002.turnbased.support.TestEnemyCombatantBuilder;
+
+@Tag("unit")
+class DefaultWaveManagerTest {
+    @Test
+    void spawnBackupIfNeeded_WhenInitialWaveDefeated_SpawnsReserveAndEmitsNarration() {
+        EnemyCombatant deadInitialEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Goblin")
+            .withCurrentHp(0)
+            .withMaxHp(30)
+            .build();
+        EnemyCombatant reserveA = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Wolf A")
+            .withHp(40)
+            .build();
+        EnemyCombatant reserveB = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Wolf B")
+            .withHp(40)
+            .build();
+
+        List<Combatant> initialEnemies = List.of(deadInitialEnemy);
+        List<Combatant> reserveEnemies = new ArrayList<>(List.of(reserveA, reserveB));
+        List<Combatant> spawnedEnemies = new ArrayList<>(List.of(deadInitialEnemy));
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        WaveManager waveManager = new DefaultWaveManager(initialEnemies, reserveEnemies, spawnedEnemies);
+        waveManager.spawnBackupIfNeeded(emittedEvents::add);
+
+        assertEquals(0, reserveEnemies.size());
+        assertEquals(3, spawnedEnemies.size());
+        assertEquals(1, emittedEvents.size());
+        NarrationEvent narrationEvent = (NarrationEvent) emittedEvents.get(0);
+        assertEquals("Backup Spawn triggered: Wolf A, Wolf B", narrationEvent.getText());
+    }
+
+    @Test
+    void spawnBackupIfNeeded_WhenInitialWaveStillAlive_DoesNothing() {
+        EnemyCombatant aliveInitialEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Goblin")
+            .withHp(30)
+            .build();
+        EnemyCombatant reserveEnemy = TestEnemyCombatantBuilder.anEnemyCombatant(new BasicAttackAction())
+            .named("Wolf")
+            .withHp(40)
+            .build();
+
+        List<Combatant> initialEnemies = List.of(aliveInitialEnemy);
+        List<Combatant> reserveEnemies = new ArrayList<>(List.of(reserveEnemy));
+        List<Combatant> spawnedEnemies = new ArrayList<>(List.of(aliveInitialEnemy));
+        List<BattleEvent> emittedEvents = new ArrayList<>();
+
+        WaveManager waveManager = new DefaultWaveManager(initialEnemies, reserveEnemies, spawnedEnemies);
+        waveManager.spawnBackupIfNeeded(emittedEvents::add);
+
+        assertEquals(1, reserveEnemies.size());
+        assertEquals(1, spawnedEnemies.size());
+        assertTrue(emittedEvents.isEmpty());
+    }
+}


### PR DESCRIPTION
Restructure battle flow to keep BattleEngine as the orchestration controller and move domain responsibilities into dedicated components.

- Extract TurnProcessor for actor turn execution
- Extract WaveManager for reinforcement spawning
- Extract RoundLifecycle for round summary and status flush
- Extract BattleOutcomeReporter for battle result narration
- Add BattleState and BattleEventPublisher to centralize state/event flow
- Add focused unit/integration tests for new collaborators and event stream consistency

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Battle engine reorganized into modular components for turn processing, round lifecycle, wave management, state tracking, and outcome reporting — clearer flow with unchanged public behavior.

* **Bug Fixes**
  * Event emission is now consistently captured and returned to listeners across runs.
  * Backup wave spawning now reliably emits a narration when triggered.

* **Improvements**
  * End-of-battle narration and round summaries now emit clearer victory/defeat and status-effect messages.

* **Tests**
  * Added unit and integration tests covering flow, events, rounds, turns, waves, and outcome narration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->